### PR TITLE
DDT: add PUP methods for derived datatypes

### DIFF
--- a/src/libs/conv-libs/ddt/ddt.C
+++ b/src/libs/conv-libs/ddt/ddt.C
@@ -1,4 +1,5 @@
 #include "ddt.h"
+#include "pup_stl.h"
 #include <algorithm>
 #include <limits>
 
@@ -29,17 +30,22 @@ CkDDT::getType(int nIndex) const
     return 0 ;
 }
 
+int
+CkDDT::getTypeTag(int nIndex) const
+{
+  return getType(nIndex)->getType();
+}
+
 void
 CkDDT::pup(PUP::er &p)
 {
   p(max_types);
   p(num_types);
-  if(p.isUnpacking())
+  p|types;
+  if (p.isUnpacking())
   {
-    typeTable = new CkDDT_DataType*[max_types];
-    types = new int[max_types];
+    typeTable.resize(max_types);
   }
-  p(types,max_types);
   int i;
   //unPacking
   if(p.isUnpacking())
@@ -95,8 +101,8 @@ CkDDT::getNextFreeIndex(void)
     if(typeTable[i] == 0)
       return i ;
   int newmax = max_types*2;
-  CkDDT_DataType** newtable = new CkDDT_DataType*[newmax];
-  int *newtype = new int[newmax];
+  vector<CkDDT_DataType*> newtable(newmax);
+  vector<int> newtype(newmax);
   for(i=0;i<max_types;i++)
   {
     newtable[i] = typeTable[i];
@@ -107,8 +113,6 @@ CkDDT::getNextFreeIndex(void)
     newtable[i] = 0;
     newtype[i] = CkDDT_TYPE_NULL;
   }
-  delete[] typeTable;
-  delete[] types;
   typeTable = newtable;
   types = newtype;
   num_types = max_types;
@@ -136,8 +140,6 @@ CkDDT::~CkDDT()
        delete typeTable[i];
     }
   }
-  delete[] typeTable ;
-  delete[] types;
 }
 
 
@@ -482,7 +484,7 @@ CkDDT_DataType::CkDDT_DataType(int datatype, int size, CkDDT_Aint extent, int co
             bool iscontig, int baseSize, CkDDT_Aint baseExtent, CkDDT_DataType* baseType, int numElements, int baseIndex,
             CkDDT_Aint trueExtent, CkDDT_Aint trueLB) :
     datatype(datatype), size(size), extent(extent), count(count), lb(lb), ub(ub), trueExtent(trueExtent),
-    trueLB(trueLB), iscontig(iscontig), baseSize(baseSize), baseExtent(baseExtent), baseType(baseType),
+    trueLB(trueLB), iscontig(iscontig), baseSize(baseSize), baseExtent(baseExtent), baseType(baseType),	// isnt this a shallow copy?
     numElements(numElements), baseIndex(baseIndex), nameLen(0), isAbsolute(false)
 {}
 
@@ -520,7 +522,7 @@ CkDDT_DataType::CkDDT_DataType(const CkDDT_DataType &obj, CkDDT_Aint _lb, CkDDT_
   count       = obj.count;
   isAbsolute  = obj.isAbsolute;
   nameLen     = obj.nameLen;
-  memcpy(name, obj.name, nameLen+1);
+  name        = obj.name;
 
   extent = _extent;
   lb     = _lb;
@@ -560,14 +562,14 @@ CkDDT_DataType::serialize(char* userdata, char* buffer, int num, int dir) const
 void
 CkDDT_DataType::setName(const char *src)
 {
-  CkDDT_SetName(name, src, &nameLen);
+  CkDDT_SetName(&name[0], src, &nameLen);
 }
 
 void
 CkDDT_DataType::getName(char *dest, int *len) const
 {
   *len = nameLen;
-  memcpy(dest, name, *len+1);
+  memcpy(dest,name.c_str(),*len+1);
 }
 
 bool
@@ -691,7 +693,7 @@ CkDDT_DataType::pupType(PUP::er  &p, CkDDT* ddt)
   p(isAbsolute);
   p(numElements);
   p(nameLen);
-  p(name,CkDDT_MAX_NAME_LEN);
+  p|name;
 }
 
 int
@@ -991,7 +993,7 @@ CkDDT_Indexed::CkDDT_Indexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp, int
     : CkDDT_DataType(CkDDT_INDEXED, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
 		     numeric_limits<CkDDT_Aint>::min(), 0, base->getSize(), base->getExtent(),
 		     base, nCount* base->getNumElements(), bindex, 0, 0),
-    arrayBlockLength(new int[nCount]), arrayDisplacements(new CkDDT_Aint[nCount])
+      arrayBlockLength(nCount), arrayDisplacements(nCount)
 {
     CkDDT_Aint positiveExtent = 0;
     CkDDT_Aint negativeExtent = 0;
@@ -1064,10 +1066,7 @@ CkDDT_Indexed::serialize(char* userdata, char* buffer, int num, int dir) const
 }
 
 CkDDT_Indexed::~CkDDT_Indexed()
-{
-  delete [] arrayBlockLength ;
-  delete [] arrayDisplacements ;
-}
+{}
 
 void
 CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
@@ -1085,12 +1084,8 @@ CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
   p(trueLB);
   p(iscontig);
   p(numElements);
-
-  if(p.isUnpacking() )  arrayBlockLength = new int[count] ;
-  p(arrayBlockLength, count);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1129,7 +1124,7 @@ CkDDT_HIndexed::CkDDT_HIndexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp,  
       ub = std::max(arrBlock[i]*baseExtent + baseType->getLB() + arrayDisplacements[i], ub);
   }
 
-  lb = baseType->getLB() + *std::min_element(arrDisp, arrDisp+nCount+1);
+  lb = baseType->getLB() + *std::min_element(&arrDisp[0],&arrDisp[0]+nCount+1);
   extent = ub - lb;
 
   trueExtent = extent;
@@ -1215,7 +1210,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
   CkDDT_DataType *type)     : CkDDT_DataType(CkDDT_INDEXED_BLOCK, 0, 0, count, numeric_limits<CkDDT_Aint>::max(),
          numeric_limits<CkDDT_Aint>::min(), 0, type->getSize(), type->getExtent(),
          type, count * type->getNumElements(), index, 0, 0),
-    BlockLength(Blength), arrayDisplacements(new CkDDT_Aint[count])
+    BlockLength(Blength), arrayDisplacements(count)
 {
   CkDDT_Aint positiveExtent = 0;
   CkDDT_Aint negativeExtent = 0;
@@ -1232,7 +1227,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
   }
 
   extent = positiveExtent + (-1)*negativeExtent;
-  lb = baseType->getLB() + *std::min_element(arrayDisplacements, arrayDisplacements + count+1)*baseExtent;
+  lb = baseType->getLB() + *std::min_element(&arrayDisplacements[0], &arrayDisplacements[0] + count+1)*baseExtent;
   ub = lb + extent;
 
   trueExtent = extent;
@@ -1261,9 +1256,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
 }
 
 CkDDT_Indexed_Block::~CkDDT_Indexed_Block()
-{
-  delete [] arrayDisplacements;
-}
+{}
 
 size_t
 CkDDT_Indexed_Block::serialize(char *userdata, char *buffer, int num, int dir) const
@@ -1310,9 +1303,7 @@ CkDDT_Indexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   p(BlockLength);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1357,7 +1348,7 @@ CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *A
   }
 
   extent = positiveExtent + (-1)*negativeExtent;
-  lb = baseType->getLB() + *std::min_element(arrayDisplacements, arrayDisplacements + count+1);
+  lb = baseType->getLB() + *std::min_element(&arrayDisplacements[0], &arrayDisplacements[0] + count+1);
   ub = lb + extent;
 
   trueExtent = extent;
@@ -1386,9 +1377,7 @@ CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *A
 }
 
 CkDDT_HIndexed_Block::~CkDDT_HIndexed_Block()
-{
-  delete [] arrayDisplacements;
-}
+{}
 
 size_t
 CkDDT_HIndexed_Block::serialize(char *userdata, char *buffer, int num, int dir) const
@@ -1435,9 +1424,7 @@ CkDDT_HIndexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   p(BlockLength);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1468,8 +1455,8 @@ CkDDT_Struct::CkDDT_Struct(int nCount, int* arrBlock,
                        CkDDT_Aint* arrDisp, int *bindex, CkDDT_DataType** arrBase)
     : CkDDT_DataType(CkDDT_STRUCT, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
     numeric_limits<CkDDT_Aint>::min(), 0, 0, 0, NULL, 0, 0, 0, 0),
-    arrayBlockLength(new int[nCount]), arrayDisplacements(new CkDDT_Aint[nCount]),
-    index(new int[nCount]), arrayDataType(new CkDDT_DataType*[nCount])
+    arrayBlockLength(nCount), arrayDisplacements(nCount),
+    index(nCount), arrayDataType(nCount)
 {
   int saveExtent = 0;
   for (int i=0; i<count; i++) {
@@ -1597,20 +1584,16 @@ CkDDT_Struct::pupType(PUP::er &p, CkDDT* ddt)
   p(trueLB);
   p(iscontig);
   p(numElements);
-  if(p.isUnpacking())
-  {
-    arrayBlockLength = new int[count] ;
-    arrayDisplacements = new CkDDT_Aint[count] ;
-    index = new int[count] ;
-    arrayDataType = new CkDDT_DataType*[count] ;
-  }
-  p(arrayBlockLength, count);
-  p(arrayDisplacements, count);
-  p(index, count);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+  p|index;
 
   if(p.isUnpacking())
+  {
+    arrayDataType.resize(count);
     for(int i=0 ; i < count; i++)
       arrayDataType[i] = ddt->getType(index[i]);
+  }
 }
 
 int

--- a/src/libs/conv-libs/ddt/ddt.C
+++ b/src/libs/conv-libs/ddt/ddt.C
@@ -696,6 +696,28 @@ CkDDT_DataType::pupType(PUP::er  &p, CkDDT* ddt)
   p|name;
 }
 
+void
+CkDDT_DataType::pup(PUP::er &p)
+{
+  p(datatype);
+  p(refCount);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(trueExtent);
+  p(trueLB);
+  p(lb);
+  p(ub);
+  p(iscontig);
+  p(isAbsolute);
+  p(numElements);
+  p(nameLen);
+  p|name;
+}
+
 int
 CkDDT_DataType::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -774,6 +796,27 @@ CkDDT_Contiguous::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
+}
+
+void
+CkDDT_Contiguous::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int
@@ -878,6 +921,29 @@ CkDDT_Vector::pupType(PUP::er &p, CkDDT* ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Vector::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(blockLength);
+  p(strideLength);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Vector::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -966,6 +1032,12 @@ void
 CkDDT_HVector::pupType(PUP::er &p, CkDDT* ddt)
 {
   CkDDT_Vector::pupType(p, ddt);
+}
+
+void
+CkDDT_HVector::pup(PUP::er &p)
+{
+  CkDDT_Vector::pup(p);
 }
 
 int
@@ -1090,6 +1162,29 @@ CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Indexed::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Indexed::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -1182,6 +1277,12 @@ void
 CkDDT_HIndexed::pupType(PUP::er &p, CkDDT* ddt)
 {
   CkDDT_Indexed::pupType(p, ddt);
+}
+
+void
+CkDDT_HIndexed::pup(PUP::er &p)
+{
+  CkDDT_Indexed::pup(p);
 }
 
 int
@@ -1308,6 +1409,29 @@ CkDDT_Indexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Indexed_Block::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p(BlockLength);
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Indexed_Block::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -1427,6 +1551,29 @@ CkDDT_HIndexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
+}
+
+void
+CkDDT_HIndexed_Block::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p(BlockLength);
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int
@@ -1594,6 +1741,27 @@ CkDDT_Struct::pupType(PUP::er &p, CkDDT* ddt)
     for(int i=0 ; i < count; i++)
       arrayDataType[i] = ddt->getType(index[i]);
   }
+}
+
+void
+CkDDT_Struct::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+  p|index;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int

--- a/src/libs/conv-libs/ddt/ddt.h
+++ b/src/libs/conv-libs/ddt/ddt.h
@@ -185,6 +185,7 @@ class CkDDT_DataType {
     virtual void inrRefCount(void) ;
     virtual int getRefCount(void) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
 
     virtual int getEnvelope(int *num_integers, int *num_addresses, int *num_datatypes, int *combiner) const;
     virtual int getContents(int max_integers, int max_addresses, int max_datatypes,
@@ -213,6 +214,7 @@ class CkDDT_Contiguous : public CkDDT_DataType {
   CkDDT_Contiguous(int count, int index, CkDDT_DataType* oldType);
   virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
   virtual void pupType(PUP::er &p, CkDDT* ddt) ;
+  virtual void pup(PUP::er &p);
   virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
   virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -244,6 +246,7 @@ class CkDDT_Vector : public CkDDT_DataType {
     ~CkDDT_Vector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -273,6 +276,7 @@ class CkDDT_HVector : public CkDDT_Vector {
     ~CkDDT_HVector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -306,6 +310,7 @@ class CkDDT_Indexed : public CkDDT_DataType {
     ~CkDDT_Indexed() ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -334,6 +339,7 @@ class CkDDT_HIndexed : public CkDDT_Indexed {
                  CkDDT_DataType* type);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -369,6 +375,7 @@ class CkDDT_Indexed_Block : public CkDDT_DataType
     ~CkDDT_Indexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -401,6 +408,7 @@ class CkDDT_HIndexed_Block : public CkDDT_Indexed_Block
     ~CkDDT_HIndexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -436,6 +444,7 @@ class CkDDT_Struct : public CkDDT_DataType {
                CkDDT_DataType **type);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void  pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };

--- a/src/libs/conv-libs/ddt/ddt.h
+++ b/src/libs/conv-libs/ddt/ddt.h
@@ -1,7 +1,12 @@
 #ifndef __CkDDT_H_
 #define __CkDDT_H_
 
+#include <string>
+#include <vector>
 #include "pup.h"
+
+using std::vector;
+using std::string;
 
 #define CkDDT_MAXTYPE           100
 
@@ -49,6 +54,8 @@
 #define CkDDT_LONG_DOUBLE_COMPLEX 40
 #define CkDDT_AINT                41
 
+#define CkDDT_MAX_PRIMITIVE_TYPE  41
+
 #define CkDDT_CONTIGUOUS          42
 #define CkDDT_VECTOR              43
 #define CkDDT_HVECTOR             44
@@ -95,33 +102,30 @@ class CkDDT ;
 
   Members:
 
-  datatype - Used for primitive datatypes for size calculations
-  refCount - to keep track of how many references are present to this type.
-
-  size - size of one unit of datatype
-  extent - extent is different from size in that it also counts
-           displacements between blocks.
-  count -  count of base datatype present in this datatype
-  baseSize - size of Base Datatype
-  baseExtent - extent of Base dataType
-  name - user specified name for datatype
-  nameLen - length of user specified name for datatype
+  datatype         - Identifies the datatype based on the identification system above.
+  refCount         - to keep track of how many references are present to this type.
+  size             - size of one unit of datatype
+  extent           - extent is different from size in that it also counts displacements between blocks.
+  count            - count of base datatype present in this datatype
+  baseSize         - size of Base Datatype
+  baseExtent       - extent of Base dataType
+  name             - user specified name for datatype
+  nameLen          - length of user specified name for datatype
 
   Methods:
 
-  getSize -  returns the size of the datatype. 
-  getExtent - returns the extent of the datatype.
+  getSize          -  returns the size of the datatype. 
+  getExtent        - returns the extent of the datatype.
 
-  inrRefCount - increament the reference count.
-  getRefCount - returns the RefCount
+  inrRefCount      - increament the reference count.
+  getRefCount      - returns the RefCount
 
-  serialize - This is the function which actually copies the contents from
-    user's space to buffer if dir=1 or reverse if dir=-1
-    according to the datatype.
-
-  setName - set the name of datatype
-  getName - get the name of datatype
-  setAbsolute - tells DDT's serialize methods that we are dealing with absolute addresses
+  serialize        - This is the function which actually copies the contents from
+                      user's space to buffer if dir=1 or reverse if dir=-1
+                      according to the datatype.
+  setName          - set the name of datatype
+  getName          - get the name of datatype
+  setAbsolute      - tells DDT's serialize methods that we are dealing with absolute addresses
 
   Reference Counting currently disabled. To add this feature back in, the refcount variable
     cannot be copied when making a duplicate.
@@ -147,7 +151,7 @@ class CkDDT_DataType {
     CkDDT_DataType *baseType;
     int baseIndex;
     int numElements;
-    char name[CkDDT_MAX_NAME_LEN];
+    string name;
     int nameLen;
     bool isAbsolute;
 
@@ -288,8 +292,8 @@ class CkDDT_HVector : public CkDDT_Vector {
 class CkDDT_Indexed : public CkDDT_DataType {
 
   protected:
-    int* arrayBlockLength ;
-    CkDDT_Aint* arrayDisplacements ;
+    vector<int> arrayBlockLength;
+    vector<CkDDT_Aint> arrayDisplacements;
 
   private:
     CkDDT_Indexed(const CkDDT_Indexed& obj);
@@ -353,7 +357,7 @@ class CkDDT_Indexed_Block : public CkDDT_DataType
 
   protected:
     int BlockLength;
-    CkDDT_Aint *arrayDisplacements;
+    vector<CkDDT_Aint> arrayDisplacements;
 
   private:
     CkDDT_Indexed_Block(const CkDDT_Indexed_Block &obj);
@@ -417,10 +421,10 @@ class CkDDT_HIndexed_Block : public CkDDT_Indexed_Block
 class CkDDT_Struct : public CkDDT_DataType {
 
   protected:
-    int* arrayBlockLength ;
-    CkDDT_Aint* arrayDisplacements ;
-    int* index;
-    CkDDT_DataType** arrayDataType;
+    vector<int> arrayBlockLength;
+    vector<CkDDT_Aint> arrayDisplacements;
+    vector<int> index;
+    vector<CkDDT_DataType*> arrayDataType;
 
   private:
     CkDDT_Struct(const CkDDT_Struct& obj);
@@ -455,8 +459,8 @@ class CkDDT_Struct : public CkDDT_DataType {
 
 class CkDDT {
   private:
-    CkDDT_DataType**  typeTable;
-    int*  types; //used for pup
+    vector<CkDDT_DataType*> typeTable;
+    vector<int> types;
     int max_types;
     int num_types;
 
@@ -466,8 +470,8 @@ class CkDDT {
   CkDDT()
   {
     max_types = CkDDT_MAXTYPE;
-    typeTable = new CkDDT_DataType*[max_types];
-    types = new int[max_types];
+    typeTable.resize(max_types);
+    types.resize(max_types);
     typeTable[0] = new CkDDT_DataType(CkDDT_DOUBLE);
     types[0] = CkDDT_DOUBLE;
     typeTable[1] = new CkDDT_DataType(CkDDT_INT);
@@ -581,6 +585,7 @@ class CkDDT {
   int   getNextFreeIndex(void);
   void  pup(PUP::er &p);
   CkDDT_DataType*  getType(int nIndex) const;
+  int getTypeTag(int nIndex) const;
 
   bool isContig(int nIndex) const;
   int getSize(int nIndex, int count=1) const;


### PR DESCRIPTION
*Original PR: https://charm.cs.illinois.edu/gerrit/2149*

---
PUP routines are needed to support RMA with derived datatypes. For now,we restrict our RMA support to derived datatypes whose base types areprimitive types, hence the assertions in the PUP routines.Change-Id: I50058750b0cfad59229e9730166df968766ae089