### PR TITLE
Shrink/Expand: Fix the calculation of oldPEs to work correctly with +n specified instead of +p

### DIFF
--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -2316,7 +2316,7 @@ static int req_handle_realloc(ChMessage *msg, SOCKET fd)
   const char **ret = (const char **) malloc(sizeof(char *) * (saved_argc + additional_args));
 
   int newP = ChMessageInt(*(ChMessageInt_t *)msg->data);
-  int oldP = arg_requested_pes;
+  int oldP = pe_to_process_map.size();
   printf("Charmrun> newp =  %d oldP = %d \n \n \n", newP, oldP);
 
   for (int i = 0; i < saved_argc; i++) {


### PR DESCRIPTION
*Original PR: https://charm.cs.illinois.edu/gerrit/3895*

---
Change-Id: I5a34320142fcb1962c18f603baa1616fc23097ae