### PR TITLE
Feature #969: AMPI support for inter-communicator (i)gather collectives.

### DIFF
--- a/tests/ampi/intercomm_coll/intercomm_coll.C
+++ b/tests/ampi/intercomm_coll/intercomm_coll.C
@@ -275,16 +275,16 @@ int main(int argc, char **argv) {
   intercomm_bcast_test(myFirstComm, global_rank, root, false); /* Intercomm bcast test */
   intercomm_bcast_test(myFirstComm, global_rank, root, true); /* Intercomm ibcast test */
 
+  /* Intercommunicator gather collective tests */
+  if (global_rank == 0) printf("[0] Testing intercomm gather\n");
+  intercomm_gather_test(myFirstComm, global_rank, root, false); /* Intercomm gather test */
+  intercomm_gather_test(myFirstComm, global_rank, root, true); /* Intercomm igather test */
+
 #if 0
   /* Intercommunicator barrier collective tests */
   if (global_rank == 0) printf("[0] Testing intercomm barrier\n");
   intercomm_barrier_test(myFirstComm, global_rank, false); /* Intercomm barrier test */
   intercomm_barrier_test(myFirstComm, global_rank, true); /* Intercomm ibarrier test */
-
-  /* Intercommunicator gather collective tests */
-  if (global_rank == 0) printf("[0] Testing intercomm gather\n");
-  intercomm_gather_test(myFirstComm, global_rank, root, false); /* Intercomm gather test */
-  intercomm_gather_test(myFirstComm, global_rank, root, true); /* Intercomm igather test */
 
   /* Intercommunicator gatherv collective tests */
   if (global_rank == 0) printf("[0] Testing intercomm gatherv\n");


### PR DESCRIPTION
*Original author: Karthik Senthil*
*Original PR: https://charm.cs.illinois.edu/gerrit/2183*

---
This implements a local (i)gather operation to an intermediate rootin the remote group ranks, which is followed by a single send of theaccumulated data to the root in local group.This patch also removes ampiCommStruct::isInter. The check for an inter-communicator is now done by checking if ampiCommStruct::localComm isMPI_COMM_NULL or not.Change-Id: I25fc1695f04437fe411ca096dbf95b7d8db9b1b4