### PR TITLE
AMPI: Update MPI version to 3.1

### DIFF
--- a/doc/ampi/manual.tex
+++ b/doc/ampi/manual.tex
@@ -16,9 +16,8 @@ derived data types support, has been developed by Neelam Saboo.
 
 \section{Introduction}
 
-This manual describes Adaptive MPI~(\ampi{}), which is an implementation of the
-MPI standard\footnote{Currently, AMPI supports the MPI-2.2 standard, and the MPI-3.1 standard is under active development,
-though we already support non-blocking and neighborhood collectives among other MPI-3.1 features.} on top of \charmpp{}.
+This manual describes Adaptive MPI~(\ampi{}), which is an implementation of version 3.1 of the
+MPI standard on top of \charmpp{}.
 \ampi{} acts as a regular MPI implementation (akin to MPICH, OpenMPI, MVAPICH, etc.)
 with several built-in extensions that allow MPI developers to take advantage of \charmpp{}'s
 dynamic runtime system, which provides support for process virtualization,

--- a/src/libs/ck-libs/ampi/ampi.h
+++ b/src/libs/ck-libs/ampi/ampi.h
@@ -138,8 +138,8 @@ typedef long long int MPI_Offset;
 #define MPI_MAX_ERROR_STRING           256
 #define MPI_MAX_LIBRARY_VERSION_STRING 256
 
-#define MPI_VERSION    2
-#define MPI_SUBVERSION 2
+#define MPI_VERSION    3
+#define MPI_SUBVERSION 1
 
 #define MPI_THREAD_SINGLE     1
 #define MPI_THREAD_FUNNELED   2

--- a/src/libs/ck-libs/ampi/ampif.h
+++ b/src/libs/ck-libs/ampi/ampif.h
@@ -65,8 +65,8 @@
        integer, parameter :: MPI_MAX_ERROR_STRING           = 256
        integer, parameter :: MPI_MAX_LIBRARY_VERSION_STRING = 256
 
-       integer, parameter :: MPI_VERSION    = 2
-       integer, parameter :: MPI_SUBVERSION = 2
+       integer, parameter :: MPI_VERSION    = 3
+       integer, parameter :: MPI_SUBVERSION = 1
 
        integer, parameter :: MPI_THREAD_SINGLE     = 1
        integer, parameter :: MPI_THREAD_FUNNELED   = 2


### PR DESCRIPTION
*Original PR: https://charm.cs.illinois.edu/gerrit/3229*

---
Our implementation is closer to 3.1 than 2.2 (especiallyregarding const arguments).Change-Id: I1cfe62bccca4c8587de9208c8e87214f48b34362