### PR TITLE
MPI Interop: add routine to run Charm++ scheduler until QD

### DIFF
--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -13,6 +13,9 @@ Initial version by Orion Sky Lawlor, olawlor@acm.org, 2/8/2002
 #include "ckcallback-ccs.h"
 #include "CkCallback.decl.h"
 #include "envelope.h"
+
+extern "C" void LibCkExit(void);
+
 /*readonly*/ CProxy_ckcallback_group _ckcallbackgroup;
 
 typedef CkHashtableT<CkHashtableAdaptorT<unsigned int>, CkCallback*> threadCB_t;
@@ -201,6 +204,10 @@ void CkCallback::send(void *msg) const
 	case ckExit: //Call ckExit
 		if (msg) CkFreeMsg(msg);
 		CkExit();
+		break;
+	case libCkExit:
+		if (msg) CkFreeMsg(msg);
+		LibCkExit();
 		break;
 	case resumeThread: //Resume a waiting thread
 		if (d.thread.onPE==CkMyPe()) {

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -36,6 +36,7 @@ public:
 	invalid=0, //Invalid callback
 	ignore, //Do nothing
 	ckExit, //Call ckExit
+	libCkExit, //Call LibCkExit
 	resumeThread, //Resume a waiting thread (d.thread)
 	callCFn, //Call a C function pointer with a parameter (d.cfn)
 	call1Fn, //Call a C function pointer on any processor (d.c1fn)

--- a/src/ck-core/mpi-interoperate.C
+++ b/src/ck-core/mpi-interoperate.C
@@ -32,6 +32,13 @@ void StartCharmScheduler() {
 }
 
 extern "C"
+void RunCharmSchedulerToQD() {
+  CmiNodeAllBarrier();
+  CkStartQD(CkCallback(CkCallback::libCkExit));
+  StartInteropScheduler();
+}
+
+extern "C"
 void StopCharmScheduler() {
   StopInteropScheduler();
 }

--- a/src/ck-core/mpi-interoperate.h
+++ b/src/ck-core/mpi-interoperate.h
@@ -17,6 +17,7 @@ extern "C" void CharmLibExit();
 extern "C" void LibCkExit(void);
 
 extern "C" void StartCharmScheduler();
+extern "C" void RunCharmSchedulerToQD();
 extern "C" void StopCharmScheduler();
 #define CkExit LibCkExit
 

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -2079,7 +2079,7 @@ void Entry::genDefs(XStr& str)
       tspec->genShort(str);
       str << ">";
     }
-      str << "));\n";
+    str << "))\n";
   }
 
   templateGuardEnd(str);


### PR DESCRIPTION
*Original author: Phil Miller*
*Original PR: https://charm.cs.illinois.edu/gerrit/811*

---
Change-Id: I3dec8e599577d0c840091901220ad462b0f11269