### PR TITLE
Bug #902: Record originating PE and event number for array element insertions

### DIFF
--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -668,6 +668,11 @@ void CProxy_ArrayBase::ckInsertIdx(CkArrayMessage *m,int ctor,int proposedPe,
 {
   if (m==NULL) m=(CkArrayMessage *)CkAllocSysMsg();
   m->array_ep()=ctor;
+
+  envelope *env = UsrToEnv(m);
+  env->getsetArraySrcPe() = CkMyPe();
+  _TRACE_CREATION_DETAILED(env, ctor);
+
   CkArray *ca = ckLocalBranch();
   if (ca == NULL) {
       CkInsertIdxMsg *msg = (CkInsertIdxMsg *)CmiAlloc(sizeof(CkInsertIdxMsg));
@@ -792,7 +797,6 @@ static void CkCreateArrayAsync(void *vmsg)
 void _ckArrayInit(void)
 {
   CkpvInitialize(ArrayElement_initInfo,initInfo);
-  CkDisableTracing(CkIndex_CkArray::insertElement(0, CkArrayIndex(), 0));
   CkDisableTracing(CkIndex_CkArray::recvBroadcast(0));
     // disable because broadcast listener may deliver broadcast message
   CkDisableTracing(CkIndex_CkLocMgr::immigrate(0));

--- a/src/ck-core/ckarray.ci
+++ b/src/ck-core/ckarray.ci
@@ -7,7 +7,7 @@ module CkArray {
   group [migratable] CkArray : CkReductionMgr {
 	entry CkArray(CkArrayOptions opts, CkMarshalledMessage ctorMsg);
 	//Insertion
-        entry [inline] void insertElement(CkMarshalledMessage, CkArrayIndex, int listenerData[CK_ARRAYLISTENER_MAXLEN]);
+        entry [notrace] void insertElement(CkMarshalledMessage, CkArrayIndex, int listenerData[CK_ARRAYLISTENER_MAXLEN]);
         entry [inline] void demandCreateElement(const CkArrayIndex &idx, int ctor, CkDeliver_t type);
         entry void remoteBeginInserting(void);
 	entry void remoteDoneInserting(void);

--- a/src/xlat-i/xi-Template.C
+++ b/src/xlat-i/xi-Template.C
@@ -255,7 +255,8 @@ void TParamList::genSpec(XStr& str)
 void
 TParamList::print(XStr& str)
 {
-  tparam->print(str);
+  if (tparam)
+    tparam->print(str);
   if(next) {
     str << ",";
     next->print(str);

--- a/src/xlat-i/xi-grammar.tab.C
+++ b/src/xlat-i/xi-grammar.tab.C
@@ -1,21 +1,24 @@
-/* A Bison parser, made by GNU Bison 2.5.  */
+/* A Bison parser, made by GNU Bison 2.3.  */
 
-/* Bison implementation for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
-   
-   This program is free software: you can redistribute it and/or modify
+/* Skeleton implementation for Bison's Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
+   Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-   
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -26,7 +29,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -44,7 +47,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.5"
+#define YYBISON_VERSION "2.3"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -52,89 +55,9 @@
 /* Pure parsers.  */
 #define YYPURE 0
 
-/* Push parsers.  */
-#define YYPUSH 0
-
-/* Pull parsers.  */
-#define YYPULL 1
-
 /* Using locations.  */
 #define YYLSP_NEEDED 1
 
-
-
-/* Copy the first part of user declarations.  */
-
-/* Line 268 of yacc.c  */
-#line 2 "xi-grammar.y"
-
-#include <iostream>
-#include <string>
-#include <string.h>
-#include "xi-symbol.h"
-#include "sdag/constructs/Constructs.h"
-#include "EToken.h"
-#include "xi-Chare.h"
-
-// Has to be a macro since YYABORT can only be used within rule actions.
-#define ERROR(...) \
-  if (xi::num_errors++ == xi::MAX_NUM_ERRORS) { \
-    YYABORT;                                    \
-  } else {                                      \
-    xi::pretty_msg("error", __VA_ARGS__);       \
-  }
-
-#define WARNING(...) \
-  if (enable_warnings) {                    \
-    xi::pretty_msg("warning", __VA_ARGS__); \
-  }
-
-using namespace xi;
-extern int yylex (void) ;
-extern unsigned char in_comment;
-extern unsigned int lineno;
-extern int in_bracket,in_braces,in_int_expr;
-extern std::list<Entry *> connectEntries;
-AstChildren<Module> *modlist;
-
-void yyerror(const char *);
-
-namespace xi {
-
-const int MAX_NUM_ERRORS = 10;
-int num_errors = 0;
-bool firstRdma = true;
-
-bool enable_warnings = true;
-
-extern int macroDefined(const char *str, int istrue);
-extern const char *python_doc;
-extern char *fname;
-void splitScopedName(const char* name, const char** scope, const char** basename);
-void ReservedWord(int token, int fCol, int lCol);
-}
-
-
-/* Line 268 of yacc.c  */
-#line 120 "y.tab.c"
-
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
-
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
-#endif
 
 
 /* Tokens.  */
@@ -294,13 +217,78 @@ void ReservedWord(int token, int fCol, int lCol);
 
 
 
+/* Copy the first part of user declarations.  */
+#line 2 "xi-grammar.y"
+
+#include <iostream>
+#include <string>
+#include <string.h>
+#include "xi-symbol.h"
+#include "sdag/constructs/Constructs.h"
+#include "EToken.h"
+#include "xi-Chare.h"
+
+// Has to be a macro since YYABORT can only be used within rule actions.
+#define ERROR(...) \
+  if (xi::num_errors++ == xi::MAX_NUM_ERRORS) { \
+    YYABORT;                                    \
+  } else {                                      \
+    xi::pretty_msg("error", __VA_ARGS__);       \
+  }
+
+#define WARNING(...) \
+  if (enable_warnings) {                    \
+    xi::pretty_msg("warning", __VA_ARGS__); \
+  }
+
+using namespace xi;
+extern int yylex (void) ;
+extern unsigned char in_comment;
+extern unsigned int lineno;
+extern int in_bracket,in_braces,in_int_expr;
+extern std::list<Entry *> connectEntries;
+AstChildren<Module> *modlist;
+
+void yyerror(const char *);
+
+namespace xi {
+
+const int MAX_NUM_ERRORS = 10;
+int num_errors = 0;
+bool firstRdma = true;
+
+bool enable_warnings = true;
+
+extern int macroDefined(const char *str, int istrue);
+extern const char *python_doc;
+extern char *fname;
+void splitScopedName(const char* name, const char** scope, const char** basename);
+void ReservedWord(int token, int fCol, int lCol);
+}
+
+
+/* Enabling traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+
+/* Enabling verbose error messages.  */
+#ifdef YYERROR_VERBOSE
+# undef YYERROR_VERBOSE
+# define YYERROR_VERBOSE 1
+#else
+# define YYERROR_VERBOSE 0
+#endif
+
+/* Enabling the token table.  */
+#ifndef YYTOKEN_TABLE
+# define YYTOKEN_TABLE 0
+#endif
+
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 typedef union YYSTYPE
-{
-
-/* Line 293 of yacc.c  */
 #line 52 "xi-grammar.y"
-
+{
   AstChildren<Module> *modlist;
   Module *module;
   ConstructList *conslist;
@@ -342,15 +330,13 @@ typedef union YYSTYPE
   SdagEntryConstruct *sentry;
   XStr* xstrptr;
   AccelBlock* accelBlock;
-
-
-
-/* Line 293 of yacc.c  */
-#line 350 "y.tab.c"
-} YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
+}
+/* Line 193 of yacc.c.  */
+#line 336 "y.tab.c"
+	YYSTYPE;
 # define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
+# define YYSTYPE_IS_TRIVIAL 1
 #endif
 
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
@@ -370,8 +356,8 @@ typedef struct YYLTYPE
 /* Copy the second part of user declarations.  */
 
 
-/* Line 343 of yacc.c  */
-#line 375 "y.tab.c"
+/* Line 216 of yacc.c.  */
+#line 361 "y.tab.c"
 
 #ifdef short
 # undef short
@@ -446,14 +432,14 @@ typedef short int yytype_int16;
 #if (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 static int
-YYID (int yyi)
+YYID (int i)
 #else
 static int
-YYID (yyi)
-    int yyi;
+YYID (i)
+    int i;
 #endif
 {
-  return yyi;
+  return i;
 }
 #endif
 
@@ -474,11 +460,11 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
+#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef EXIT_SUCCESS
-#      define EXIT_SUCCESS 0
+#     ifndef _STDLIB_H
+#      define _STDLIB_H 1
 #     endif
 #    endif
 #   endif
@@ -501,24 +487,24 @@ YYID (yyi)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
+#  if (defined __cplusplus && ! defined _STDLIB_H \
        && ! ((defined YYMALLOC || defined malloc) \
 	     && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef EXIT_SUCCESS
-#    define EXIT_SUCCESS 0
+#   ifndef _STDLIB_H
+#    define _STDLIB_H 1
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
+#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
+#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
@@ -535,9 +521,9 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
-  YYSTYPE yyvs_alloc;
-  YYLTYPE yyls_alloc;
+  yytype_int16 yyss;
+  YYSTYPE yyvs;
+    YYLTYPE yyls;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
@@ -549,27 +535,6 @@ union yyalloc
      ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE) + sizeof (YYLTYPE)) \
       + 2 * YYSTACK_GAP_MAXIMUM)
 
-# define YYCOPY_NEEDED 1
-
-/* Relocate STACK from its old location to the new one.  The
-   local variables YYSIZE and YYSTACKSIZE give the old and new number of
-   elements in the stack, and YYPTR gives the new location of the
-   stack.  Advance YYPTR to a properly aligned location for the next
-   stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
-
-#endif
-
-#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
 /* Copy COUNT objects from FROM to TO.  The source and destination do
    not overlap.  */
 # ifndef YYCOPY
@@ -587,7 +552,24 @@ union yyalloc
       while (YYID (0))
 #  endif
 # endif
-#endif /* !YYCOPY_NEEDED */
+
+/* Relocate STACK from its old location to the new one.  The
+   local variables YYSIZE and YYSTACKSIZE give the old and new number of
+   elements in the stack, and YYPTR gives the new location of the
+   stack.  Advance YYPTR to a properly aligned location for the next
+   stack.  */
+# define YYSTACK_RELOCATE(Stack)					\
+    do									\
+      {									\
+	YYSIZE_T yynewbytes;						\
+	YYCOPY (&yyptr->Stack, Stack, yysize);				\
+	Stack = &yyptr->Stack;						\
+	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+	yyptr += yynewbytes / sizeof (*yyptr);				\
+      }									\
+    while (YYID (0))
+
+#endif
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  56
@@ -1019,8 +1001,8 @@ static const yytype_uint8 yyr2[] =
        2,     2
 };
 
-/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
-   Performed when YYTABLE doesn't specify something else to do.  Zero
+/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
+   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_uint16 yydefact[] =
 {
@@ -1215,7 +1197,8 @@ static const yytype_int16 yypgoto[] =
 
 /* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+   number is the opposite.  If zero, do what YYDEFACT says.
+   If YYTABLE_NINF, syntax error.  */
 #define YYTABLE_NINF -323
 static const yytype_int16 yytable[] =
 {
@@ -1372,12 +1355,6 @@ static const yytype_int16 yytable[] =
        0,     0,     0,     0,     0,    81,     0,     0,     0,     0,
        0,   133,   134,   135,   136,   137,   138,   139
 };
-
-#define yypact_value_is_default(yystate) \
-  ((yystate) == (-603))
-
-#define yytable_value_is_error(yytable_value) \
-  YYID (0)
 
 static const yytype_int16 yycheck[] =
 {
@@ -1626,18 +1603,9 @@ static const yytype_uint8 yystos[] =
 
 /* Like YYERROR except do call yyerror.  This remains here temporarily
    to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+   Once GCC version 2 has supplanted version 1, this can go.  */
 
 #define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
@@ -1647,6 +1615,7 @@ do								\
     {								\
       yychar = (Token);						\
       yylval = (Value);						\
+      yytoken = YYTRANSLATE (yychar);				\
       YYPOPSTACK (1);						\
       goto yybackup;						\
     }								\
@@ -1809,20 +1778,17 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
 #if (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yytype_int16 *bottom, yytype_int16 *top)
 #else
 static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
+yy_stack_print (bottom, top)
+    yytype_int16 *bottom;
+    yytype_int16 *top;
 #endif
 {
   YYFPRINTF (stderr, "Stack now");
-  for (; yybottom <= yytop; yybottom++)
-    {
-      int yybot = *yybottom;
-      YYFPRINTF (stderr, " %d", yybot);
-    }
+  for (; bottom <= top; ++bottom)
+    YYFPRINTF (stderr, " %d", *bottom);
   YYFPRINTF (stderr, "\n");
 }
 
@@ -1857,11 +1823,11 @@ yy_reduce_print (yyvsp, yylsp, yyrule)
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
-      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      fprintf (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
 		       &(yyvsp[(yyi + 1) - (yynrhs)])
 		       , &(yylsp[(yyi + 1) - (yynrhs)])		       );
-      YYFPRINTF (stderr, "\n");
+      fprintf (stderr, "\n");
     }
 }
 
@@ -1898,6 +1864,7 @@ int yydebug;
 # define YYMAXDEPTH 10000
 #endif
 
+
 
 #if YYERROR_VERBOSE
 
@@ -2000,142 +1967,115 @@ yytnamerr (char *yyres, const char *yystr)
 }
 # endif
 
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+/* Copy into YYRESULT an error message about the unexpected token
+   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
+   including the terminating null byte.  If YYRESULT is null, do not
+   copy anything; just return the number of bytes that would be
+   copied.  As a special case, return 0 if an ordinary "syntax error"
+   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
+   size calculation.  */
+static YYSIZE_T
+yysyntax_error (char *yyresult, int yystate, int yychar)
 {
-  YYSIZE_T yysize0 = yytnamerr (0, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
-  YYSIZE_T yysize1;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = 0;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
-  int yycount = 0;
+  int yyn = yypact[yystate];
 
-  /* There are many possibilities here to consider:
-     - Assume YYFAIL is not used.  It's too flawed to consider.  See
-       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
-       for details.  YYERROR is fine as it does not invoke this
-       function.
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
+  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
+    return 0;
+  else
     {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
+      int yytype = YYTRANSLATE (yychar);
+      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
+      YYSIZE_T yysize = yysize0;
+      YYSIZE_T yysize1;
+      int yysize_overflow = 0;
+      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
+      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+      int yyx;
 
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-                if (! (yysize <= yysize1
-                       && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                  return 2;
-                yysize = yysize1;
-              }
-        }
+# if 0
+      /* This is so xgettext sees the translatable formats that are
+	 constructed on the fly.  */
+      YY_("syntax error, unexpected %s");
+      YY_("syntax error, unexpected %s, expecting %s");
+      YY_("syntax error, unexpected %s, expecting %s or %s");
+      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
+      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
+# endif
+      char *yyfmt;
+      char const *yyf;
+      static char const yyunexpected[] = "syntax error, unexpected %s";
+      static char const yyexpecting[] = ", expecting %s";
+      static char const yyor[] = " or %s";
+      char yyformat[sizeof yyunexpected
+		    + sizeof yyexpecting - 1
+		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
+		       * (sizeof yyor - 1))];
+      char const *yyprefix = yyexpecting;
+
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+	 YYCHECK.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yycount = 1;
+
+      yyarg[0] = yytname[yytype];
+      yyfmt = yystpcpy (yyformat, yyunexpected);
+
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
+	  {
+	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
+	      {
+		yycount = 1;
+		yysize = yysize0;
+		yyformat[sizeof yyunexpected - 1] = '\0';
+		break;
+	      }
+	    yyarg[yycount++] = yytname[yyx];
+	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
+	    yysize_overflow |= (yysize1 < yysize);
+	    yysize = yysize1;
+	    yyfmt = yystpcpy (yyfmt, yyprefix);
+	    yyprefix = yyor;
+	  }
+
+      yyf = YY_(yyformat);
+      yysize1 = yysize + yystrlen (yyf);
+      yysize_overflow |= (yysize1 < yysize);
+      yysize = yysize1;
+
+      if (yysize_overflow)
+	return YYSIZE_MAXIMUM;
+
+      if (yyresult)
+	{
+	  /* Avoid sprintf, as that infringes on the user's name space.
+	     Don't have undefined behavior even if the translation
+	     produced a string with the wrong number of "%s"s.  */
+	  char *yyp = yyresult;
+	  int yyi = 0;
+	  while ((*yyp = *yyf) != '\0')
+	    {
+	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
+		{
+		  yyp += yytnamerr (yyp, yyarg[yyi++]);
+		  yyf += 2;
+		}
+	      else
+		{
+		  yyp++;
+		  yyf++;
+		}
+	    }
+	}
+      return yysize;
     }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  yysize1 = yysize + yystrlen (yyformat);
-  if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-    return 2;
-  yysize = yysize1;
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          yyp++;
-          yyformat++;
-        }
-  }
-  return 0;
 }
 #endif /* YYERROR_VERBOSE */
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
@@ -2169,9 +2109,10 @@ yydestruct (yymsg, yytype, yyvaluep, yylocationp)
 	break;
     }
 }
-
+
 
 /* Prevent warnings from -Wmissing-prototypes.  */
+
 #ifdef YYPARSE_PARAM
 #if defined __STDC__ || defined __cplusplus
 int yyparse (void *YYPARSE_PARAM);
@@ -2187,17 +2128,18 @@ int yyparse ();
 #endif /* ! YYPARSE_PARAM */
 
 
-/* The lookahead symbol.  */
+
+/* The look-ahead symbol.  */
 int yychar;
 
-/* The semantic value of the lookahead symbol.  */
+/* The semantic value of the look-ahead symbol.  */
 YYSTYPE yylval;
-
-/* Location data for the lookahead symbol.  */
-YYLTYPE yylloc;
 
 /* Number of syntax errors so far.  */
 int yynerrs;
+/* Location data for the look-ahead symbol.  */
+YYLTYPE yylloc;
+
 
 
 /*----------.
@@ -2226,47 +2168,14 @@ yyparse ()
 #endif
 #endif
 {
-    int yystate;
-    /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
-
-    /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-       `yyls': related to locations.
-
-       Refer to the stacks thru separate pointers, to allow yyoverflow
-       to reallocate them elsewhere.  */
-
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
-
-    /* The semantic value stack.  */
-    YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    /* The location stack.  */
-    YYLTYPE yylsa[YYINITDEPTH];
-    YYLTYPE *yyls;
-    YYLTYPE *yylsp;
-
-    /* The locations where the error started and ended.  */
-    YYLTYPE yyerror_range[3];
-
-    YYSIZE_T yystacksize;
-
+  
+  int yystate;
   int yyn;
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken;
-  /* The variables used to return semantic value and location from the
-     action routines.  */
-  YYSTYPE yyval;
-  YYLTYPE yyloc;
-
+  /* Number of tokens to shift before error messages enabled.  */
+  int yyerrstatus;
+  /* Look-ahead token as an internal (translated) token number.  */
+  int yytoken = 0;
 #if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
@@ -2274,37 +2183,63 @@ yyparse ()
   YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
+  /* Three stacks and their tools:
+     `yyss': related to states,
+     `yyvs': related to semantic values,
+     `yyls': related to locations.
+
+     Refer to the stacks thru separate pointers, to allow yyoverflow
+     to reallocate them elsewhere.  */
+
+  /* The state stack.  */
+  yytype_int16 yyssa[YYINITDEPTH];
+  yytype_int16 *yyss = yyssa;
+  yytype_int16 *yyssp;
+
+  /* The semantic value stack.  */
+  YYSTYPE yyvsa[YYINITDEPTH];
+  YYSTYPE *yyvs = yyvsa;
+  YYSTYPE *yyvsp;
+
+  /* The location stack.  */
+  YYLTYPE yylsa[YYINITDEPTH];
+  YYLTYPE *yyls = yylsa;
+  YYLTYPE *yylsp;
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[2];
+
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
+
+  YYSIZE_T yystacksize = YYINITDEPTH;
+
+  /* The variables used to return semantic value and location from the
+     action routines.  */
+  YYSTYPE yyval;
+  YYLTYPE yyloc;
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
-
-  yytoken = 0;
-  yyss = yyssa;
-  yyvs = yyvsa;
-  yyls = yylsa;
-  yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yystate = 0;
   yyerrstatus = 0;
   yynerrs = 0;
-  yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = YYEMPTY;		/* Cause a token to be read.  */
 
   /* Initialize stack pointers.
      Waste one element of value and location stack
      so that they stay on the same level as the state stack.
      The wasted elements are never initialized.  */
+
   yyssp = yyss;
   yyvsp = yyvs;
   yylsp = yyls;
-
 #if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
   /* Initialize the default location before parsing starts.  */
   yylloc.first_line   = yylloc.last_line   = 1;
-  yylloc.first_column = yylloc.last_column = 1;
+  yylloc.first_column = yylloc.last_column = 0;
 #endif
 
   goto yysetstate;
@@ -2343,7 +2278,6 @@ yyparse ()
 		    &yyvs1, yysize * sizeof (*yyvsp),
 		    &yyls1, yysize * sizeof (*yylsp),
 		    &yystacksize);
-
 	yyls = yyls1;
 	yyss = yyss1;
 	yyvs = yyvs1;
@@ -2365,9 +2299,9 @@ yyparse ()
 	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
 	if (! yyptr)
 	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-	YYSTACK_RELOCATE (yyls_alloc, yyls);
+	YYSTACK_RELOCATE (yyss);
+	YYSTACK_RELOCATE (yyvs);
+	YYSTACK_RELOCATE (yyls);
 #  undef YYSTACK_RELOCATE
 	if (yyss1 != yyssa)
 	  YYSTACK_FREE (yyss1);
@@ -2388,9 +2322,6 @@ yyparse ()
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
-  if (yystate == YYFINAL)
-    YYACCEPT;
-
   goto yybackup;
 
 /*-----------.
@@ -2399,16 +2330,16 @@ yyparse ()
 yybackup:
 
   /* Do appropriate processing given the current state.  Read a
-     lookahead token if we need one and don't already have one.  */
+     look-ahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to lookahead token.  */
+  /* First try to decide what to do without reference to look-ahead token.  */
   yyn = yypact[yystate];
-  if (yypact_value_is_default (yyn))
+  if (yyn == YYPACT_NINF)
     goto yydefault;
 
-  /* Not known => get a lookahead token if don't already have one.  */
+  /* Not known => get a look-ahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either YYEMPTY or YYEOF or a valid look-ahead symbol.  */
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
@@ -2434,22 +2365,26 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yytable_value_is_error (yyn))
-        goto yyerrlab;
+      if (yyn == 0 || yyn == YYTABLE_NINF)
+	goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
+
+  if (yyn == YYFINAL)
+    YYACCEPT;
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
-  /* Shift the lookahead token.  */
+  /* Shift the look-ahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
 
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
+  /* Discard the shifted token unless it is eof.  */
+  if (yychar != YYEOF)
+    yychar = YYEMPTY;
 
   yystate = yyn;
   *++yyvsp = yylval;
@@ -2490,15 +2425,11 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-
-/* Line 1806 of yacc.c  */
 #line 195 "xi-grammar.y"
     { (yyval.modlist) = (yyvsp[(1) - (1)].modlist); modlist = (yyvsp[(1) - (1)].modlist); }
     break;
 
   case 3:
-
-/* Line 1806 of yacc.c  */
 #line 199 "xi-grammar.y"
     { 
 		  (yyval.modlist) = 0; 
@@ -2506,400 +2437,286 @@ yyreduce:
     break;
 
   case 4:
-
-/* Line 1806 of yacc.c  */
 #line 203 "xi-grammar.y"
     { (yyval.modlist) = new AstChildren<Module>(lineno, (yyvsp[(1) - (2)].module), (yyvsp[(2) - (2)].modlist)); }
     break;
 
   case 5:
-
-/* Line 1806 of yacc.c  */
 #line 207 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 6:
-
-/* Line 1806 of yacc.c  */
 #line 209 "xi-grammar.y"
     { (yyval.intval) = 1; }
     break;
 
   case 7:
-
-/* Line 1806 of yacc.c  */
 #line 213 "xi-grammar.y"
     { (yyval.intval) = 1; }
     break;
 
   case 8:
-
-/* Line 1806 of yacc.c  */
 #line 215 "xi-grammar.y"
     { (yyval.intval) = 2; }
     break;
 
   case 9:
-
-/* Line 1806 of yacc.c  */
 #line 219 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 10:
-
-/* Line 1806 of yacc.c  */
 #line 221 "xi-grammar.y"
     { (yyval.intval) = 1; }
     break;
 
   case 11:
-
-/* Line 1806 of yacc.c  */
 #line 226 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(1) - (1)].strval); }
     break;
 
   case 12:
-
-/* Line 1806 of yacc.c  */
 #line 227 "xi-grammar.y"
     { ReservedWord(MODULE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 13:
-
-/* Line 1806 of yacc.c  */
 #line 228 "xi-grammar.y"
     { ReservedWord(MAINMODULE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 14:
-
-/* Line 1806 of yacc.c  */
 #line 229 "xi-grammar.y"
     { ReservedWord(EXTERN, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 15:
-
-/* Line 1806 of yacc.c  */
 #line 231 "xi-grammar.y"
     { ReservedWord(INITCALL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 16:
-
-/* Line 1806 of yacc.c  */
 #line 232 "xi-grammar.y"
     { ReservedWord(INITNODE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 17:
-
-/* Line 1806 of yacc.c  */
 #line 233 "xi-grammar.y"
     { ReservedWord(INITPROC, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 18:
-
-/* Line 1806 of yacc.c  */
 #line 235 "xi-grammar.y"
     { ReservedWord(CHARE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 19:
-
-/* Line 1806 of yacc.c  */
 #line 236 "xi-grammar.y"
     { ReservedWord(MAINCHARE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 20:
-
-/* Line 1806 of yacc.c  */
 #line 237 "xi-grammar.y"
     { ReservedWord(GROUP, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 21:
-
-/* Line 1806 of yacc.c  */
 #line 238 "xi-grammar.y"
     { ReservedWord(NODEGROUP, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 22:
-
-/* Line 1806 of yacc.c  */
 #line 239 "xi-grammar.y"
     { ReservedWord(ARRAY, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 23:
-
-/* Line 1806 of yacc.c  */
 #line 243 "xi-grammar.y"
     { ReservedWord(INCLUDE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 24:
-
-/* Line 1806 of yacc.c  */
 #line 244 "xi-grammar.y"
     { ReservedWord(STACKSIZE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 25:
-
-/* Line 1806 of yacc.c  */
 #line 245 "xi-grammar.y"
     { ReservedWord(THREADED, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 26:
-
-/* Line 1806 of yacc.c  */
 #line 246 "xi-grammar.y"
     { ReservedWord(TEMPLATE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 27:
-
-/* Line 1806 of yacc.c  */
 #line 247 "xi-grammar.y"
     { ReservedWord(SYNC, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 28:
-
-/* Line 1806 of yacc.c  */
 #line 248 "xi-grammar.y"
     { ReservedWord(IGET, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 29:
-
-/* Line 1806 of yacc.c  */
 #line 249 "xi-grammar.y"
     { ReservedWord(EXCLUSIVE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 30:
-
-/* Line 1806 of yacc.c  */
 #line 250 "xi-grammar.y"
     { ReservedWord(IMMEDIATE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 31:
-
-/* Line 1806 of yacc.c  */
 #line 251 "xi-grammar.y"
     { ReservedWord(SKIPSCHED, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 32:
-
-/* Line 1806 of yacc.c  */
 #line 252 "xi-grammar.y"
     { ReservedWord(NOCOPY, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 33:
-
-/* Line 1806 of yacc.c  */
 #line 253 "xi-grammar.y"
     { ReservedWord(INLINE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 34:
-
-/* Line 1806 of yacc.c  */
 #line 254 "xi-grammar.y"
     { ReservedWord(VIRTUAL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 35:
-
-/* Line 1806 of yacc.c  */
 #line 255 "xi-grammar.y"
     { ReservedWord(MIGRATABLE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 36:
-
-/* Line 1806 of yacc.c  */
 #line 256 "xi-grammar.y"
     { ReservedWord(CREATEHERE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 37:
-
-/* Line 1806 of yacc.c  */
 #line 257 "xi-grammar.y"
     { ReservedWord(CREATEHOME, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 38:
-
-/* Line 1806 of yacc.c  */
 #line 258 "xi-grammar.y"
     { ReservedWord(NOKEEP, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 39:
-
-/* Line 1806 of yacc.c  */
 #line 259 "xi-grammar.y"
     { ReservedWord(NOTRACE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 40:
-
-/* Line 1806 of yacc.c  */
 #line 260 "xi-grammar.y"
     { ReservedWord(APPWORK, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 41:
-
-/* Line 1806 of yacc.c  */
 #line 263 "xi-grammar.y"
     { ReservedWord(PACKED, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 42:
-
-/* Line 1806 of yacc.c  */
 #line 264 "xi-grammar.y"
     { ReservedWord(VARSIZE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 43:
-
-/* Line 1806 of yacc.c  */
 #line 265 "xi-grammar.y"
     { ReservedWord(ENTRY, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 44:
-
-/* Line 1806 of yacc.c  */
 #line 266 "xi-grammar.y"
     { ReservedWord(FOR, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 45:
-
-/* Line 1806 of yacc.c  */
 #line 267 "xi-grammar.y"
     { ReservedWord(FORALL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 46:
-
-/* Line 1806 of yacc.c  */
 #line 268 "xi-grammar.y"
     { ReservedWord(WHILE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 47:
-
-/* Line 1806 of yacc.c  */
 #line 269 "xi-grammar.y"
     { ReservedWord(WHEN, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 48:
-
-/* Line 1806 of yacc.c  */
 #line 270 "xi-grammar.y"
     { ReservedWord(OVERLAP, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 49:
-
-/* Line 1806 of yacc.c  */
 #line 271 "xi-grammar.y"
     { ReservedWord(SERIAL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 50:
-
-/* Line 1806 of yacc.c  */
 #line 272 "xi-grammar.y"
     { ReservedWord(IF, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 51:
-
-/* Line 1806 of yacc.c  */
 #line 273 "xi-grammar.y"
     { ReservedWord(ELSE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 52:
-
-/* Line 1806 of yacc.c  */
 #line 275 "xi-grammar.y"
     { ReservedWord(LOCAL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 53:
-
-/* Line 1806 of yacc.c  */
 #line 277 "xi-grammar.y"
     { ReservedWord(USING, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 54:
-
-/* Line 1806 of yacc.c  */
 #line 278 "xi-grammar.y"
     { ReservedWord(ACCEL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 55:
-
-/* Line 1806 of yacc.c  */
 #line 281 "xi-grammar.y"
     { ReservedWord(ACCELBLOCK, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 56:
-
-/* Line 1806 of yacc.c  */
 #line 282 "xi-grammar.y"
     { ReservedWord(MEMCRITICAL, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 57:
-
-/* Line 1806 of yacc.c  */
 #line 283 "xi-grammar.y"
     { ReservedWord(REDUCTIONTARGET, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 58:
-
-/* Line 1806 of yacc.c  */
 #line 284 "xi-grammar.y"
     { ReservedWord(CASE, (yyloc).first_column, (yyloc).last_column); YYABORT; }
     break;
 
   case 59:
-
-/* Line 1806 of yacc.c  */
 #line 289 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(1) - (1)].strval); }
     break;
 
   case 60:
-
-/* Line 1806 of yacc.c  */
 #line 291 "xi-grammar.y"
     {
 		  char *tmp = new char[strlen((yyvsp[(1) - (4)].strval))+strlen((yyvsp[(4) - (4)].strval))+3];
@@ -2909,8 +2726,6 @@ yyreduce:
     break;
 
   case 61:
-
-/* Line 1806 of yacc.c  */
 #line 298 "xi-grammar.y"
     { 
 		    (yyval.module) = new Module(lineno, (yyvsp[(2) - (3)].strval), (yyvsp[(3) - (3)].conslist)); 
@@ -2918,8 +2733,6 @@ yyreduce:
     break;
 
   case 62:
-
-/* Line 1806 of yacc.c  */
 #line 302 "xi-grammar.y"
     {  
 		    (yyval.module) = new Module(lineno, (yyvsp[(2) - (3)].strval), (yyvsp[(3) - (3)].conslist)); 
@@ -2928,64 +2741,46 @@ yyreduce:
     break;
 
   case 63:
-
-/* Line 1806 of yacc.c  */
 #line 309 "xi-grammar.y"
     { (yyval.conslist) = 0; }
     break;
 
   case 64:
-
-/* Line 1806 of yacc.c  */
 #line 311 "xi-grammar.y"
     { (yyval.conslist) = (yyvsp[(2) - (4)].conslist); }
     break;
 
   case 65:
-
-/* Line 1806 of yacc.c  */
 #line 315 "xi-grammar.y"
     { (yyval.conslist) = 0; }
     break;
 
   case 66:
-
-/* Line 1806 of yacc.c  */
 #line 317 "xi-grammar.y"
     { (yyval.conslist) = new ConstructList(lineno, (yyvsp[(1) - (2)].construct), (yyvsp[(2) - (2)].conslist)); }
     break;
 
   case 67:
-
-/* Line 1806 of yacc.c  */
 #line 321 "xi-grammar.y"
     { (yyval.construct) = new UsingScope((yyvsp[(3) - (3)].strval), false); }
     break;
 
   case 68:
-
-/* Line 1806 of yacc.c  */
 #line 323 "xi-grammar.y"
     { (yyval.construct) = new UsingScope((yyvsp[(2) - (2)].strval), true); }
     break;
 
   case 69:
-
-/* Line 1806 of yacc.c  */
 #line 325 "xi-grammar.y"
     { (yyvsp[(2) - (2)].member)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].member); }
     break;
 
   case 70:
-
-/* Line 1806 of yacc.c  */
 #line 327 "xi-grammar.y"
     { (yyvsp[(2) - (2)].message)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].message); }
     break;
 
   case 71:
-
-/* Line 1806 of yacc.c  */
 #line 329 "xi-grammar.y"
     {
                   Entry *e = new Entry(lineno, 0, (yyvsp[(3) - (7)].type), (yyvsp[(5) - (7)].strval), (yyvsp[(7) - (7)].plist), 0, 0, 0, (yylsp[(1) - (7)]).first_line, (yyloc).last_line);
@@ -3000,29 +2795,21 @@ yyreduce:
     break;
 
   case 72:
-
-/* Line 1806 of yacc.c  */
 #line 342 "xi-grammar.y"
     { if((yyvsp[(3) - (5)].conslist)) (yyvsp[(3) - (5)].conslist)->recurse<int&>((yyvsp[(1) - (5)].intval), &Construct::setExtern); (yyval.construct) = (yyvsp[(3) - (5)].conslist); }
     break;
 
   case 73:
-
-/* Line 1806 of yacc.c  */
 #line 344 "xi-grammar.y"
     { (yyval.construct) = new Scope((yyvsp[(2) - (5)].strval), (yyvsp[(4) - (5)].conslist)); }
     break;
 
   case 74:
-
-/* Line 1806 of yacc.c  */
 #line 346 "xi-grammar.y"
     { (yyval.construct) = (yyvsp[(1) - (2)].construct); }
     break;
 
   case 75:
-
-/* Line 1806 of yacc.c  */
 #line 348 "xi-grammar.y"
     {
           ERROR("preceding construct must be semicolon terminated",
@@ -3032,71 +2819,51 @@ yyreduce:
     break;
 
   case 76:
-
-/* Line 1806 of yacc.c  */
 #line 354 "xi-grammar.y"
     { (yyvsp[(2) - (2)].module)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].module); }
     break;
 
   case 77:
-
-/* Line 1806 of yacc.c  */
 #line 356 "xi-grammar.y"
     { (yyvsp[(2) - (2)].chare)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].chare); }
     break;
 
   case 78:
-
-/* Line 1806 of yacc.c  */
 #line 358 "xi-grammar.y"
     { (yyvsp[(2) - (2)].chare)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].chare); }
     break;
 
   case 79:
-
-/* Line 1806 of yacc.c  */
 #line 360 "xi-grammar.y"
     { (yyvsp[(2) - (2)].chare)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].chare); }
     break;
 
   case 80:
-
-/* Line 1806 of yacc.c  */
 #line 362 "xi-grammar.y"
     { (yyvsp[(2) - (2)].chare)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].chare); }
     break;
 
   case 81:
-
-/* Line 1806 of yacc.c  */
 #line 364 "xi-grammar.y"
     { (yyvsp[(2) - (2)].templat)->setExtern((yyvsp[(1) - (2)].intval)); (yyval.construct) = (yyvsp[(2) - (2)].templat); }
     break;
 
   case 82:
-
-/* Line 1806 of yacc.c  */
 #line 366 "xi-grammar.y"
     { (yyval.construct) = NULL; }
     break;
 
   case 83:
-
-/* Line 1806 of yacc.c  */
 #line 368 "xi-grammar.y"
     { (yyval.construct) = NULL; }
     break;
 
   case 84:
-
-/* Line 1806 of yacc.c  */
 #line 370 "xi-grammar.y"
     { (yyval.construct) = (yyvsp[(1) - (1)].accelBlock); }
     break;
 
   case 85:
-
-/* Line 1806 of yacc.c  */
 #line 372 "xi-grammar.y"
     {
           ERROR("invalid construct",
@@ -3106,183 +2873,131 @@ yyreduce:
     break;
 
   case 86:
-
-/* Line 1806 of yacc.c  */
 #line 380 "xi-grammar.y"
     { (yyval.tparam) = new TParamType((yyvsp[(1) - (1)].type)); }
     break;
 
   case 87:
-
-/* Line 1806 of yacc.c  */
 #line 382 "xi-grammar.y"
     { (yyval.tparam) = new TParamVal((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 88:
-
-/* Line 1806 of yacc.c  */
 #line 384 "xi-grammar.y"
     { (yyval.tparam) = new TParamVal((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 89:
-
-/* Line 1806 of yacc.c  */
 #line 388 "xi-grammar.y"
     { (yyval.tparlist) = new TParamList((yyvsp[(1) - (1)].tparam)); }
     break;
 
   case 90:
-
-/* Line 1806 of yacc.c  */
 #line 390 "xi-grammar.y"
     { (yyval.tparlist) = new TParamList((yyvsp[(1) - (3)].tparam), (yyvsp[(3) - (3)].tparlist)); }
     break;
 
   case 91:
-
-/* Line 1806 of yacc.c  */
 #line 394 "xi-grammar.y"
-    { (yyval.tparlist) = 0; }
+    { (yyval.tparlist) = new TParamList(0); }
     break;
 
   case 92:
-
-/* Line 1806 of yacc.c  */
 #line 396 "xi-grammar.y"
     { (yyval.tparlist) = (yyvsp[(1) - (1)].tparlist); }
     break;
 
   case 93:
-
-/* Line 1806 of yacc.c  */
 #line 400 "xi-grammar.y"
     { (yyval.tparlist) = 0; }
     break;
 
   case 94:
-
-/* Line 1806 of yacc.c  */
 #line 402 "xi-grammar.y"
     { (yyval.tparlist) = (yyvsp[(2) - (3)].tparlist); }
     break;
 
   case 95:
-
-/* Line 1806 of yacc.c  */
 #line 406 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("int"); }
     break;
 
   case 96:
-
-/* Line 1806 of yacc.c  */
 #line 408 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("long"); }
     break;
 
   case 97:
-
-/* Line 1806 of yacc.c  */
 #line 410 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("short"); }
     break;
 
   case 98:
-
-/* Line 1806 of yacc.c  */
 #line 412 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("char"); }
     break;
 
   case 99:
-
-/* Line 1806 of yacc.c  */
 #line 414 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned int"); }
     break;
 
   case 100:
-
-/* Line 1806 of yacc.c  */
 #line 416 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned long"); }
     break;
 
   case 101:
-
-/* Line 1806 of yacc.c  */
 #line 418 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned long"); }
     break;
 
   case 102:
-
-/* Line 1806 of yacc.c  */
 #line 420 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned long long"); }
     break;
 
   case 103:
-
-/* Line 1806 of yacc.c  */
 #line 422 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned short"); }
     break;
 
   case 104:
-
-/* Line 1806 of yacc.c  */
 #line 424 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("unsigned char"); }
     break;
 
   case 105:
-
-/* Line 1806 of yacc.c  */
 #line 426 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("long long"); }
     break;
 
   case 106:
-
-/* Line 1806 of yacc.c  */
 #line 428 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("float"); }
     break;
 
   case 107:
-
-/* Line 1806 of yacc.c  */
 #line 430 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("double"); }
     break;
 
   case 108:
-
-/* Line 1806 of yacc.c  */
 #line 432 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("long double"); }
     break;
 
   case 109:
-
-/* Line 1806 of yacc.c  */
 #line 434 "xi-grammar.y"
     { (yyval.type) = new BuiltinType("void"); }
     break;
 
   case 110:
-
-/* Line 1806 of yacc.c  */
 #line 437 "xi-grammar.y"
     { (yyval.ntype) = new NamedType((yyvsp[(1) - (2)].strval),(yyvsp[(2) - (2)].tparlist)); }
     break;
 
   case 111:
-
-/* Line 1806 of yacc.c  */
 #line 438 "xi-grammar.y"
     { 
                     const char* basename, *scope;
@@ -3292,218 +3007,156 @@ yyreduce:
     break;
 
   case 112:
-
-/* Line 1806 of yacc.c  */
 #line 446 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 113:
-
-/* Line 1806 of yacc.c  */
 #line 448 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ntype); }
     break;
 
   case 114:
-
-/* Line 1806 of yacc.c  */
 #line 452 "xi-grammar.y"
     { (yyval.ptype) = new PtrType((yyvsp[(1) - (2)].type)); }
     break;
 
   case 115:
-
-/* Line 1806 of yacc.c  */
 #line 456 "xi-grammar.y"
     { (yyvsp[(1) - (2)].ptype)->indirect(); (yyval.ptype) = (yyvsp[(1) - (2)].ptype); }
     break;
 
   case 116:
-
-/* Line 1806 of yacc.c  */
 #line 458 "xi-grammar.y"
     { (yyvsp[(1) - (2)].ptype)->indirect(); (yyval.ptype) = (yyvsp[(1) - (2)].ptype); }
     break;
 
   case 117:
-
-/* Line 1806 of yacc.c  */
 #line 462 "xi-grammar.y"
     { (yyval.ftype) = new FuncType((yyvsp[(1) - (8)].type), (yyvsp[(4) - (8)].strval), (yyvsp[(7) - (8)].plist)); }
     break;
 
   case 118:
-
-/* Line 1806 of yacc.c  */
 #line 466 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 119:
-
-/* Line 1806 of yacc.c  */
 #line 468 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ptype); }
     break;
 
   case 120:
-
-/* Line 1806 of yacc.c  */
 #line 470 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ptype); }
     break;
 
   case 121:
-
-/* Line 1806 of yacc.c  */
 #line 472 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ftype); }
     break;
 
   case 122:
-
-/* Line 1806 of yacc.c  */
 #line 474 "xi-grammar.y"
     { (yyval.type) = new ConstType((yyvsp[(2) - (2)].type)); }
     break;
 
   case 123:
-
-/* Line 1806 of yacc.c  */
 #line 476 "xi-grammar.y"
     { (yyval.type) = new ConstType((yyvsp[(1) - (2)].type)); }
     break;
 
   case 124:
-
-/* Line 1806 of yacc.c  */
 #line 480 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 125:
-
-/* Line 1806 of yacc.c  */
 #line 482 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ptype); }
     break;
 
   case 126:
-
-/* Line 1806 of yacc.c  */
 #line 484 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].ptype); }
     break;
 
   case 127:
-
-/* Line 1806 of yacc.c  */
 #line 486 "xi-grammar.y"
     { (yyval.type) = new ConstType((yyvsp[(2) - (2)].type)); }
     break;
 
   case 128:
-
-/* Line 1806 of yacc.c  */
 #line 488 "xi-grammar.y"
     { (yyval.type) = new ConstType((yyvsp[(1) - (2)].type)); }
     break;
 
   case 129:
-
-/* Line 1806 of yacc.c  */
 #line 492 "xi-grammar.y"
     { (yyval.type) = new ReferenceType((yyvsp[(1) - (2)].type)); }
     break;
 
   case 130:
-
-/* Line 1806 of yacc.c  */
 #line 494 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 131:
-
-/* Line 1806 of yacc.c  */
 #line 498 "xi-grammar.y"
     { (yyval.type) = new ReferenceType((yyvsp[(1) - (2)].type)); }
     break;
 
   case 132:
-
-/* Line 1806 of yacc.c  */
 #line 500 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 133:
-
-/* Line 1806 of yacc.c  */
 #line 504 "xi-grammar.y"
     { (yyval.val) = new Value((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 134:
-
-/* Line 1806 of yacc.c  */
 #line 508 "xi-grammar.y"
     { (yyval.val) = (yyvsp[(2) - (3)].val); }
     break;
 
   case 135:
-
-/* Line 1806 of yacc.c  */
 #line 512 "xi-grammar.y"
     { (yyval.vallist) = 0; }
     break;
 
   case 136:
-
-/* Line 1806 of yacc.c  */
 #line 514 "xi-grammar.y"
     { (yyval.vallist) = new ValueList((yyvsp[(1) - (2)].val), (yyvsp[(2) - (2)].vallist)); }
     break;
 
   case 137:
-
-/* Line 1806 of yacc.c  */
 #line 518 "xi-grammar.y"
     { (yyval.readonly) = new Readonly(lineno, (yyvsp[(2) - (4)].type), (yyvsp[(3) - (4)].strval), (yyvsp[(4) - (4)].vallist)); }
     break;
 
   case 138:
-
-/* Line 1806 of yacc.c  */
 #line 522 "xi-grammar.y"
     { (yyval.readonly) = new Readonly(lineno, (yyvsp[(3) - (6)].type), (yyvsp[(5) - (6)].strval), (yyvsp[(6) - (6)].vallist), 1); }
     break;
 
   case 139:
-
-/* Line 1806 of yacc.c  */
 #line 526 "xi-grammar.y"
     { (yyval.intval) = 0;}
     break;
 
   case 140:
-
-/* Line 1806 of yacc.c  */
 #line 528 "xi-grammar.y"
     { (yyval.intval) = 0;}
     break;
 
   case 141:
-
-/* Line 1806 of yacc.c  */
 #line 532 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 142:
-
-/* Line 1806 of yacc.c  */
 #line 534 "xi-grammar.y"
     { 
 		  /*
@@ -3515,253 +3168,181 @@ yyreduce:
     break;
 
   case 143:
-
-/* Line 1806 of yacc.c  */
 #line 544 "xi-grammar.y"
     { (yyval.intval) = (yyvsp[(1) - (1)].intval); }
     break;
 
   case 144:
-
-/* Line 1806 of yacc.c  */
 #line 546 "xi-grammar.y"
     { (yyval.intval) = (yyvsp[(1) - (3)].intval) | (yyvsp[(3) - (3)].intval); }
     break;
 
   case 145:
-
-/* Line 1806 of yacc.c  */
 #line 550 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 146:
-
-/* Line 1806 of yacc.c  */
 #line 552 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 147:
-
-/* Line 1806 of yacc.c  */
 #line 556 "xi-grammar.y"
     { (yyval.cattr) = 0; }
     break;
 
   case 148:
-
-/* Line 1806 of yacc.c  */
 #line 558 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(2) - (3)].cattr); }
     break;
 
   case 149:
-
-/* Line 1806 of yacc.c  */
 #line 562 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(1) - (1)].cattr); }
     break;
 
   case 150:
-
-/* Line 1806 of yacc.c  */
 #line 564 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(1) - (3)].cattr) | (yyvsp[(3) - (3)].cattr); }
     break;
 
   case 151:
-
-/* Line 1806 of yacc.c  */
 #line 568 "xi-grammar.y"
     { python_doc = NULL; (yyval.intval) = 0; }
     break;
 
   case 152:
-
-/* Line 1806 of yacc.c  */
 #line 570 "xi-grammar.y"
     { python_doc = (yyvsp[(1) - (1)].strval); (yyval.intval) = 0; }
     break;
 
   case 153:
-
-/* Line 1806 of yacc.c  */
 #line 574 "xi-grammar.y"
     { (yyval.cattr) = Chare::CPYTHON; }
     break;
 
   case 154:
-
-/* Line 1806 of yacc.c  */
 #line 578 "xi-grammar.y"
     { (yyval.cattr) = 0; }
     break;
 
   case 155:
-
-/* Line 1806 of yacc.c  */
 #line 580 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(2) - (3)].cattr); }
     break;
 
   case 156:
-
-/* Line 1806 of yacc.c  */
 #line 584 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(1) - (1)].cattr); }
     break;
 
   case 157:
-
-/* Line 1806 of yacc.c  */
 #line 586 "xi-grammar.y"
     { (yyval.cattr) = (yyvsp[(1) - (3)].cattr) | (yyvsp[(3) - (3)].cattr); }
     break;
 
   case 158:
-
-/* Line 1806 of yacc.c  */
 #line 590 "xi-grammar.y"
     { (yyval.cattr) = Chare::CMIGRATABLE; }
     break;
 
   case 159:
-
-/* Line 1806 of yacc.c  */
 #line 592 "xi-grammar.y"
     { (yyval.cattr) = Chare::CPYTHON; }
     break;
 
   case 160:
-
-/* Line 1806 of yacc.c  */
 #line 596 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 161:
-
-/* Line 1806 of yacc.c  */
 #line 598 "xi-grammar.y"
     { (yyval.intval) = 1; }
     break;
 
   case 162:
-
-/* Line 1806 of yacc.c  */
 #line 601 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 163:
-
-/* Line 1806 of yacc.c  */
 #line 603 "xi-grammar.y"
     { (yyval.intval) = 1; }
     break;
 
   case 164:
-
-/* Line 1806 of yacc.c  */
 #line 606 "xi-grammar.y"
     { (yyval.mv) = new MsgVar((yyvsp[(2) - (5)].type), (yyvsp[(3) - (5)].strval), (yyvsp[(1) - (5)].intval), (yyvsp[(4) - (5)].intval)); }
     break;
 
   case 165:
-
-/* Line 1806 of yacc.c  */
 #line 610 "xi-grammar.y"
     { (yyval.mvlist) = new MsgVarList((yyvsp[(1) - (1)].mv)); }
     break;
 
   case 166:
-
-/* Line 1806 of yacc.c  */
 #line 612 "xi-grammar.y"
     { (yyval.mvlist) = new MsgVarList((yyvsp[(1) - (2)].mv), (yyvsp[(2) - (2)].mvlist)); }
     break;
 
   case 167:
-
-/* Line 1806 of yacc.c  */
 #line 616 "xi-grammar.y"
     { (yyval.message) = new Message(lineno, (yyvsp[(3) - (3)].ntype)); }
     break;
 
   case 168:
-
-/* Line 1806 of yacc.c  */
 #line 618 "xi-grammar.y"
     { (yyval.message) = new Message(lineno, (yyvsp[(3) - (5)].ntype)); }
     break;
 
   case 169:
-
-/* Line 1806 of yacc.c  */
 #line 620 "xi-grammar.y"
     { (yyval.message) = new Message(lineno, (yyvsp[(3) - (6)].ntype), (yyvsp[(5) - (6)].mvlist)); }
     break;
 
   case 170:
-
-/* Line 1806 of yacc.c  */
 #line 624 "xi-grammar.y"
     { (yyval.typelist) = 0; }
     break;
 
   case 171:
-
-/* Line 1806 of yacc.c  */
 #line 626 "xi-grammar.y"
     { (yyval.typelist) = (yyvsp[(2) - (2)].typelist); }
     break;
 
   case 172:
-
-/* Line 1806 of yacc.c  */
 #line 630 "xi-grammar.y"
     { (yyval.typelist) = new TypeList((yyvsp[(1) - (1)].ntype)); }
     break;
 
   case 173:
-
-/* Line 1806 of yacc.c  */
 #line 632 "xi-grammar.y"
     { (yyval.typelist) = new TypeList((yyvsp[(1) - (3)].ntype), (yyvsp[(3) - (3)].typelist)); }
     break;
 
   case 174:
-
-/* Line 1806 of yacc.c  */
 #line 636 "xi-grammar.y"
     { (yyval.chare) = new Chare(lineno, (yyvsp[(2) - (5)].cattr)|Chare::CCHARE, (yyvsp[(3) - (5)].ntype), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 175:
-
-/* Line 1806 of yacc.c  */
 #line 638 "xi-grammar.y"
     { (yyval.chare) = new MainChare(lineno, (yyvsp[(2) - (5)].cattr), (yyvsp[(3) - (5)].ntype), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 176:
-
-/* Line 1806 of yacc.c  */
 #line 642 "xi-grammar.y"
     { (yyval.chare) = new Group(lineno, (yyvsp[(2) - (5)].cattr), (yyvsp[(3) - (5)].ntype), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 177:
-
-/* Line 1806 of yacc.c  */
 #line 646 "xi-grammar.y"
     { (yyval.chare) = new NodeGroup(lineno, (yyvsp[(2) - (5)].cattr), (yyvsp[(3) - (5)].ntype), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 178:
-
-/* Line 1806 of yacc.c  */
 #line 650 "xi-grammar.y"
     {/*Stupid special case for [1D] indices*/
 			char *buf=new char[40];
@@ -3771,113 +3352,81 @@ yyreduce:
     break;
 
   case 179:
-
-/* Line 1806 of yacc.c  */
 #line 656 "xi-grammar.y"
     { (yyval.ntype) = new NamedType((yyvsp[(2) - (3)].strval)); }
     break;
 
   case 180:
-
-/* Line 1806 of yacc.c  */
 #line 660 "xi-grammar.y"
     {  (yyval.chare) = new Array(lineno, (yyvsp[(2) - (6)].cattr), (yyvsp[(3) - (6)].ntype), (yyvsp[(4) - (6)].ntype), (yyvsp[(5) - (6)].typelist), (yyvsp[(6) - (6)].mbrlist)); }
     break;
 
   case 181:
-
-/* Line 1806 of yacc.c  */
 #line 662 "xi-grammar.y"
     {  (yyval.chare) = new Array(lineno, (yyvsp[(3) - (6)].cattr), (yyvsp[(2) - (6)].ntype), (yyvsp[(4) - (6)].ntype), (yyvsp[(5) - (6)].typelist), (yyvsp[(6) - (6)].mbrlist)); }
     break;
 
   case 182:
-
-/* Line 1806 of yacc.c  */
 #line 666 "xi-grammar.y"
     { (yyval.chare) = new Chare(lineno, (yyvsp[(2) - (5)].cattr)|Chare::CCHARE, new NamedType((yyvsp[(3) - (5)].strval)), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist));}
     break;
 
   case 183:
-
-/* Line 1806 of yacc.c  */
 #line 668 "xi-grammar.y"
     { (yyval.chare) = new MainChare(lineno, (yyvsp[(2) - (5)].cattr), new NamedType((yyvsp[(3) - (5)].strval)), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 184:
-
-/* Line 1806 of yacc.c  */
 #line 672 "xi-grammar.y"
     { (yyval.chare) = new Group(lineno, (yyvsp[(2) - (5)].cattr), new NamedType((yyvsp[(3) - (5)].strval)), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 185:
-
-/* Line 1806 of yacc.c  */
 #line 676 "xi-grammar.y"
     { (yyval.chare) = new NodeGroup( lineno, (yyvsp[(2) - (5)].cattr), new NamedType((yyvsp[(3) - (5)].strval)), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 186:
-
-/* Line 1806 of yacc.c  */
 #line 680 "xi-grammar.y"
     { (yyval.chare) = new Array( lineno, 0, (yyvsp[(2) - (5)].ntype), new NamedType((yyvsp[(3) - (5)].strval)), (yyvsp[(4) - (5)].typelist), (yyvsp[(5) - (5)].mbrlist)); }
     break;
 
   case 187:
-
-/* Line 1806 of yacc.c  */
 #line 684 "xi-grammar.y"
     { (yyval.message) = new Message(lineno, new NamedType((yyvsp[(3) - (4)].strval))); }
     break;
 
   case 188:
-
-/* Line 1806 of yacc.c  */
 #line 686 "xi-grammar.y"
     { (yyval.message) = new Message(lineno, new NamedType((yyvsp[(3) - (7)].strval)), (yyvsp[(5) - (7)].mvlist)); }
     break;
 
   case 189:
-
-/* Line 1806 of yacc.c  */
 #line 690 "xi-grammar.y"
     { (yyval.type) = 0; }
     break;
 
   case 190:
-
-/* Line 1806 of yacc.c  */
 #line 692 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(2) - (2)].type); }
     break;
 
   case 191:
-
-/* Line 1806 of yacc.c  */
 #line 696 "xi-grammar.y"
     { (yyval.strval) = 0; }
     break;
 
   case 192:
-
-/* Line 1806 of yacc.c  */
 #line 698 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(2) - (2)].strval); }
     break;
 
   case 193:
-
-/* Line 1806 of yacc.c  */
 #line 700 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(2) - (2)].strval); }
     break;
 
   case 194:
-
-/* Line 1806 of yacc.c  */
 #line 702 "xi-grammar.y"
     {
 		  XStr typeStr;
@@ -3888,99 +3437,71 @@ yyreduce:
     break;
 
   case 195:
-
-/* Line 1806 of yacc.c  */
 #line 711 "xi-grammar.y"
     { (yyval.tvar) = new TType(new NamedType((yyvsp[(2) - (3)].strval)), (yyvsp[(3) - (3)].type)); }
     break;
 
   case 196:
-
-/* Line 1806 of yacc.c  */
 #line 713 "xi-grammar.y"
     { (yyval.tvar) = new TFunc((yyvsp[(1) - (2)].ftype), (yyvsp[(2) - (2)].strval)); }
     break;
 
   case 197:
-
-/* Line 1806 of yacc.c  */
 #line 715 "xi-grammar.y"
     { (yyval.tvar) = new TName((yyvsp[(1) - (3)].type), (yyvsp[(2) - (3)].strval), (yyvsp[(3) - (3)].strval)); }
     break;
 
   case 198:
-
-/* Line 1806 of yacc.c  */
 #line 719 "xi-grammar.y"
     { (yyval.tvarlist) = new TVarList((yyvsp[(1) - (1)].tvar)); }
     break;
 
   case 199:
-
-/* Line 1806 of yacc.c  */
 #line 721 "xi-grammar.y"
     { (yyval.tvarlist) = new TVarList((yyvsp[(1) - (3)].tvar), (yyvsp[(3) - (3)].tvarlist)); }
     break;
 
   case 200:
-
-/* Line 1806 of yacc.c  */
 #line 725 "xi-grammar.y"
     { (yyval.tvarlist) = (yyvsp[(3) - (4)].tvarlist); }
     break;
 
   case 201:
-
-/* Line 1806 of yacc.c  */
 #line 729 "xi-grammar.y"
     { (yyval.templat) = new Template((yyvsp[(1) - (2)].tvarlist), (yyvsp[(2) - (2)].chare)); (yyvsp[(2) - (2)].chare)->setTemplate((yyval.templat)); }
     break;
 
   case 202:
-
-/* Line 1806 of yacc.c  */
 #line 731 "xi-grammar.y"
     { (yyval.templat) = new Template((yyvsp[(1) - (2)].tvarlist), (yyvsp[(2) - (2)].chare)); (yyvsp[(2) - (2)].chare)->setTemplate((yyval.templat)); }
     break;
 
   case 203:
-
-/* Line 1806 of yacc.c  */
 #line 733 "xi-grammar.y"
     { (yyval.templat) = new Template((yyvsp[(1) - (2)].tvarlist), (yyvsp[(2) - (2)].chare)); (yyvsp[(2) - (2)].chare)->setTemplate((yyval.templat)); }
     break;
 
   case 204:
-
-/* Line 1806 of yacc.c  */
 #line 735 "xi-grammar.y"
     { (yyval.templat) = new Template((yyvsp[(1) - (2)].tvarlist), (yyvsp[(2) - (2)].chare)); (yyvsp[(2) - (2)].chare)->setTemplate((yyval.templat)); }
     break;
 
   case 205:
-
-/* Line 1806 of yacc.c  */
 #line 737 "xi-grammar.y"
     { (yyval.templat) = new Template((yyvsp[(1) - (2)].tvarlist), (yyvsp[(2) - (2)].message)); (yyvsp[(2) - (2)].message)->setTemplate((yyval.templat)); }
     break;
 
   case 206:
-
-/* Line 1806 of yacc.c  */
 #line 741 "xi-grammar.y"
     { (yyval.mbrlist) = 0; }
     break;
 
   case 207:
-
-/* Line 1806 of yacc.c  */
 #line 743 "xi-grammar.y"
     { (yyval.mbrlist) = (yyvsp[(2) - (4)].mbrlist); }
     break;
 
   case 208:
-
-/* Line 1806 of yacc.c  */
 #line 747 "xi-grammar.y"
     { 
                   if (!connectEntries.empty()) {
@@ -3992,71 +3513,51 @@ yyreduce:
     break;
 
   case 209:
-
-/* Line 1806 of yacc.c  */
 #line 755 "xi-grammar.y"
     { (yyval.mbrlist) = new AstChildren<Member>(-1, (yyvsp[(1) - (2)].member), (yyvsp[(2) - (2)].mbrlist)); }
     break;
 
   case 210:
-
-/* Line 1806 of yacc.c  */
 #line 759 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (1)].readonly); }
     break;
 
   case 211:
-
-/* Line 1806 of yacc.c  */
 #line 761 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (1)].readonly); }
     break;
 
   case 213:
-
-/* Line 1806 of yacc.c  */
 #line 764 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (1)].member); }
     break;
 
   case 214:
-
-/* Line 1806 of yacc.c  */
 #line 766 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(2) - (2)].pupable); }
     break;
 
   case 215:
-
-/* Line 1806 of yacc.c  */
 #line 768 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(2) - (2)].includeFile); }
     break;
 
   case 216:
-
-/* Line 1806 of yacc.c  */
 #line 770 "xi-grammar.y"
     { (yyval.member) = new ClassDeclaration(lineno,(yyvsp[(2) - (2)].strval)); }
     break;
 
   case 217:
-
-/* Line 1806 of yacc.c  */
 #line 774 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno, (yyvsp[(3) - (3)].strval), 1); }
     break;
 
   case 218:
-
-/* Line 1806 of yacc.c  */
 #line 776 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno, (yyvsp[(3) - (6)].strval), 1); }
     break;
 
   case 219:
-
-/* Line 1806 of yacc.c  */
 #line 778 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno,
 				    strdup((std::string((yyvsp[(3) - (9)].strval)) + '<' +
@@ -4066,8 +3567,6 @@ yyreduce:
     break;
 
   case 220:
-
-/* Line 1806 of yacc.c  */
 #line 784 "xi-grammar.y"
     {
 		  WARNING("deprecated use of initcall. Use initnode or initproc instead",
@@ -4077,8 +3576,6 @@ yyreduce:
     break;
 
   case 221:
-
-/* Line 1806 of yacc.c  */
 #line 790 "xi-grammar.y"
     {
 		  WARNING("deprecated use of initcall. Use initnode or initproc instead",
@@ -4088,22 +3585,16 @@ yyreduce:
     break;
 
   case 222:
-
-/* Line 1806 of yacc.c  */
 #line 799 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno, (yyvsp[(3) - (3)].strval), 0); }
     break;
 
   case 223:
-
-/* Line 1806 of yacc.c  */
 #line 801 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno, (yyvsp[(3) - (6)].strval), 0); }
     break;
 
   case 224:
-
-/* Line 1806 of yacc.c  */
 #line 803 "xi-grammar.y"
     { (yyval.member) = new InitCall(lineno,
 				    strdup((std::string((yyvsp[(3) - (9)].strval)) + '<' +
@@ -4113,8 +3604,6 @@ yyreduce:
     break;
 
   case 225:
-
-/* Line 1806 of yacc.c  */
 #line 809 "xi-grammar.y"
     {
                   InitCall* rtn = new InitCall(lineno, (yyvsp[(6) - (9)].strval), 0);
@@ -4124,43 +3613,31 @@ yyreduce:
     break;
 
   case 226:
-
-/* Line 1806 of yacc.c  */
 #line 817 "xi-grammar.y"
     { (yyval.pupable) = new PUPableClass(lineno,(yyvsp[(1) - (1)].ntype),0); }
     break;
 
   case 227:
-
-/* Line 1806 of yacc.c  */
 #line 819 "xi-grammar.y"
     { (yyval.pupable) = new PUPableClass(lineno,(yyvsp[(1) - (3)].ntype),(yyvsp[(3) - (3)].pupable)); }
     break;
 
   case 228:
-
-/* Line 1806 of yacc.c  */
 #line 822 "xi-grammar.y"
     { (yyval.includeFile) = new IncludeFile(lineno,(yyvsp[(1) - (1)].strval)); }
     break;
 
   case 229:
-
-/* Line 1806 of yacc.c  */
 #line 826 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (1)].member); }
     break;
 
   case 230:
-
-/* Line 1806 of yacc.c  */
 #line 830 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (1)].entry); }
     break;
 
   case 231:
-
-/* Line 1806 of yacc.c  */
 #line 832 "xi-grammar.y"
     {
                   (yyvsp[(2) - (2)].entry)->tspec = (yyvsp[(1) - (2)].tvarlist);
@@ -4169,15 +3646,11 @@ yyreduce:
     break;
 
   case 232:
-
-/* Line 1806 of yacc.c  */
 #line 837 "xi-grammar.y"
     { (yyval.member) = (yyvsp[(1) - (2)].member); }
     break;
 
   case 233:
-
-/* Line 1806 of yacc.c  */
 #line 839 "xi-grammar.y"
     {
           ERROR("invalid SDAG member",
@@ -4187,85 +3660,61 @@ yyreduce:
     break;
 
   case 234:
-
-/* Line 1806 of yacc.c  */
 #line 847 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 235:
-
-/* Line 1806 of yacc.c  */
 #line 849 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 236:
-
-/* Line 1806 of yacc.c  */
 #line 851 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 237:
-
-/* Line 1806 of yacc.c  */
 #line 853 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 238:
-
-/* Line 1806 of yacc.c  */
 #line 855 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 239:
-
-/* Line 1806 of yacc.c  */
 #line 857 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 240:
-
-/* Line 1806 of yacc.c  */
 #line 859 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 241:
-
-/* Line 1806 of yacc.c  */
 #line 861 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 242:
-
-/* Line 1806 of yacc.c  */
 #line 863 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 243:
-
-/* Line 1806 of yacc.c  */
 #line 865 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 244:
-
-/* Line 1806 of yacc.c  */
 #line 867 "xi-grammar.y"
     { (yyval.member) = 0; }
     break;
 
   case 245:
-
-/* Line 1806 of yacc.c  */
 #line 870 "xi-grammar.y"
     { 
                   (yyval.entry) = new Entry(lineno, (yyvsp[(2) - (7)].intval), (yyvsp[(3) - (7)].type), (yyvsp[(4) - (7)].strval), (yyvsp[(5) - (7)].plist), (yyvsp[(6) - (7)].val), (yyvsp[(7) - (7)].sentry), (const char *) NULL, (yylsp[(1) - (7)]).first_line, (yyloc).last_line);
@@ -4279,8 +3728,6 @@ yyreduce:
     break;
 
   case 246:
-
-/* Line 1806 of yacc.c  */
 #line 880 "xi-grammar.y"
     { 
                   Entry *e = new Entry(lineno, (yyvsp[(2) - (5)].intval), 0, (yyvsp[(3) - (5)].strval), (yyvsp[(4) - (5)].plist),  0, (yyvsp[(5) - (5)].sentry), (const char *) NULL, (yylsp[(1) - (5)]).first_line, (yyloc).last_line);
@@ -4301,8 +3748,6 @@ yyreduce:
     break;
 
   case 247:
-
-/* Line 1806 of yacc.c  */
 #line 897 "xi-grammar.y"
     {
                   int attribs = SACCEL;
@@ -4321,43 +3766,31 @@ yyreduce:
     break;
 
   case 248:
-
-/* Line 1806 of yacc.c  */
 #line 914 "xi-grammar.y"
     { (yyval.accelBlock) = new AccelBlock(lineno, new XStr((yyvsp[(3) - (5)].strval))); }
     break;
 
   case 249:
-
-/* Line 1806 of yacc.c  */
 #line 916 "xi-grammar.y"
     { (yyval.accelBlock) = new AccelBlock(lineno, NULL); }
     break;
 
   case 250:
-
-/* Line 1806 of yacc.c  */
 #line 920 "xi-grammar.y"
     { (yyval.type) = (yyvsp[(1) - (1)].type); }
     break;
 
   case 251:
-
-/* Line 1806 of yacc.c  */
 #line 924 "xi-grammar.y"
     { (yyval.intval) = 0; }
     break;
 
   case 252:
-
-/* Line 1806 of yacc.c  */
 #line 926 "xi-grammar.y"
     { (yyval.intval) = (yyvsp[(2) - (3)].intval); }
     break;
 
   case 253:
-
-/* Line 1806 of yacc.c  */
 #line 928 "xi-grammar.y"
     { ERROR("invalid entry method attribute list",
 		        (yyloc).first_column, (yyloc).last_column);
@@ -4366,134 +3799,96 @@ yyreduce:
     break;
 
   case 254:
-
-/* Line 1806 of yacc.c  */
 #line 935 "xi-grammar.y"
     { (yyval.intval) = (yyvsp[(1) - (1)].intval); }
     break;
 
   case 255:
-
-/* Line 1806 of yacc.c  */
 #line 937 "xi-grammar.y"
     { (yyval.intval) = (yyvsp[(1) - (3)].intval) | (yyvsp[(3) - (3)].intval); }
     break;
 
   case 256:
-
-/* Line 1806 of yacc.c  */
 #line 941 "xi-grammar.y"
     { (yyval.intval) = STHREADED; }
     break;
 
   case 257:
-
-/* Line 1806 of yacc.c  */
 #line 943 "xi-grammar.y"
     { (yyval.intval) = SSYNC; }
     break;
 
   case 258:
-
-/* Line 1806 of yacc.c  */
 #line 945 "xi-grammar.y"
     { (yyval.intval) = SIGET; }
     break;
 
   case 259:
-
-/* Line 1806 of yacc.c  */
 #line 947 "xi-grammar.y"
     { (yyval.intval) = SLOCKED; }
     break;
 
   case 260:
-
-/* Line 1806 of yacc.c  */
 #line 949 "xi-grammar.y"
     { (yyval.intval) = SCREATEHERE; }
     break;
 
   case 261:
-
-/* Line 1806 of yacc.c  */
 #line 951 "xi-grammar.y"
     { (yyval.intval) = SCREATEHOME; }
     break;
 
   case 262:
-
-/* Line 1806 of yacc.c  */
 #line 953 "xi-grammar.y"
     { (yyval.intval) = SNOKEEP; }
     break;
 
   case 263:
-
-/* Line 1806 of yacc.c  */
 #line 955 "xi-grammar.y"
     { (yyval.intval) = SNOTRACE; }
     break;
 
   case 264:
-
-/* Line 1806 of yacc.c  */
 #line 957 "xi-grammar.y"
     { (yyval.intval) = SAPPWORK; }
     break;
 
   case 265:
-
-/* Line 1806 of yacc.c  */
 #line 959 "xi-grammar.y"
     { (yyval.intval) = SIMMEDIATE; }
     break;
 
   case 266:
-
-/* Line 1806 of yacc.c  */
 #line 961 "xi-grammar.y"
     { (yyval.intval) = SSKIPSCHED; }
     break;
 
   case 267:
-
-/* Line 1806 of yacc.c  */
 #line 963 "xi-grammar.y"
     { (yyval.intval) = SINLINE; }
     break;
 
   case 268:
-
-/* Line 1806 of yacc.c  */
 #line 965 "xi-grammar.y"
     { (yyval.intval) = SLOCAL; }
     break;
 
   case 269:
-
-/* Line 1806 of yacc.c  */
 #line 967 "xi-grammar.y"
     { (yyval.intval) = SPYTHON; }
     break;
 
   case 270:
-
-/* Line 1806 of yacc.c  */
 #line 969 "xi-grammar.y"
     { (yyval.intval) = SMEM; }
     break;
 
   case 271:
-
-/* Line 1806 of yacc.c  */
 #line 971 "xi-grammar.y"
     { (yyval.intval) = SREDUCE; }
     break;
 
   case 272:
-
-/* Line 1806 of yacc.c  */
 #line 973 "xi-grammar.y"
     {
 #ifdef CMK_USING_XLC
@@ -4509,8 +3904,6 @@ yyreduce:
     break;
 
   case 273:
-
-/* Line 1806 of yacc.c  */
 #line 985 "xi-grammar.y"
     {
 		  ERROR("invalid entry method attribute",
@@ -4521,43 +3914,31 @@ yyreduce:
     break;
 
   case 274:
-
-/* Line 1806 of yacc.c  */
 #line 994 "xi-grammar.y"
     { (yyval.val) = new Value((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 275:
-
-/* Line 1806 of yacc.c  */
 #line 996 "xi-grammar.y"
     { (yyval.val) = new Value((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 276:
-
-/* Line 1806 of yacc.c  */
 #line 998 "xi-grammar.y"
     { (yyval.val) = new Value((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 277:
-
-/* Line 1806 of yacc.c  */
 #line 1002 "xi-grammar.y"
     { (yyval.strval) = ""; }
     break;
 
   case 278:
-
-/* Line 1806 of yacc.c  */
 #line 1004 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(1) - (1)].strval); }
     break;
 
   case 279:
-
-/* Line 1806 of yacc.c  */
 #line 1006 "xi-grammar.y"
     {  /*Returned only when in_bracket*/
 			char *tmp = new char[strlen((yyvsp[(1) - (3)].strval))+strlen((yyvsp[(3) - (3)].strval))+3];
@@ -4567,22 +3948,16 @@ yyreduce:
     break;
 
   case 280:
-
-/* Line 1806 of yacc.c  */
 #line 1014 "xi-grammar.y"
     { (yyval.strval) = ""; }
     break;
 
   case 281:
-
-/* Line 1806 of yacc.c  */
 #line 1016 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(1) - (1)].strval); }
     break;
 
   case 282:
-
-/* Line 1806 of yacc.c  */
 #line 1018 "xi-grammar.y"
     {  /*Returned only when in_bracket*/
 			char *tmp = new char[strlen((yyvsp[(1) - (5)].strval))+strlen((yyvsp[(3) - (5)].strval))+strlen((yyvsp[(5) - (5)].strval))+3];
@@ -4592,8 +3967,6 @@ yyreduce:
     break;
 
   case 283:
-
-/* Line 1806 of yacc.c  */
 #line 1024 "xi-grammar.y"
     { /*Returned only when in_braces*/
 			char *tmp = new char[strlen((yyvsp[(1) - (5)].strval))+strlen((yyvsp[(3) - (5)].strval))+strlen((yyvsp[(5) - (5)].strval))+3];
@@ -4603,8 +3976,6 @@ yyreduce:
     break;
 
   case 284:
-
-/* Line 1806 of yacc.c  */
 #line 1030 "xi-grammar.y"
     { /*Returned only when in_braces*/
 			char *tmp = new char[strlen((yyvsp[(1) - (5)].strval))+strlen((yyvsp[(3) - (5)].strval))+strlen((yyvsp[(5) - (5)].strval))+3];
@@ -4614,8 +3985,6 @@ yyreduce:
     break;
 
   case 285:
-
-/* Line 1806 of yacc.c  */
 #line 1036 "xi-grammar.y"
     { /*Returned only when in_braces*/
 			char *tmp = new char[strlen((yyvsp[(2) - (4)].strval))+strlen((yyvsp[(4) - (4)].strval))+3];
@@ -4625,8 +3994,6 @@ yyreduce:
     break;
 
   case 286:
-
-/* Line 1806 of yacc.c  */
 #line 1044 "xi-grammar.y"
     {  /*Start grabbing CPROGRAM segments*/
 			in_bracket=1;
@@ -4635,8 +4002,6 @@ yyreduce:
     break;
 
   case 287:
-
-/* Line 1806 of yacc.c  */
 #line 1051 "xi-grammar.y"
     { 
                    /*Start grabbing CPROGRAM segments*/
@@ -4646,8 +4011,6 @@ yyreduce:
     break;
 
   case 288:
-
-/* Line 1806 of yacc.c  */
 #line 1059 "xi-grammar.y"
     { 
 			in_braces=0;
@@ -4656,29 +4019,21 @@ yyreduce:
     break;
 
   case 289:
-
-/* Line 1806 of yacc.c  */
 #line 1066 "xi-grammar.y"
     { (yyval.pname) = new Parameter(lineno, (yyvsp[(1) - (1)].type));}
     break;
 
   case 290:
-
-/* Line 1806 of yacc.c  */
 #line 1068 "xi-grammar.y"
     { (yyval.pname) = new Parameter(lineno, (yyvsp[(1) - (3)].type),(yyvsp[(2) - (3)].strval)); (yyval.pname)->setConditional((yyvsp[(3) - (3)].intval)); }
     break;
 
   case 291:
-
-/* Line 1806 of yacc.c  */
 #line 1070 "xi-grammar.y"
     { (yyval.pname) = new Parameter(lineno, (yyvsp[(1) - (4)].type),(yyvsp[(2) - (4)].strval),0,(yyvsp[(4) - (4)].val));}
     break;
 
   case 292:
-
-/* Line 1806 of yacc.c  */
 #line 1072 "xi-grammar.y"
     { /*Stop grabbing CPROGRAM segments*/
 			in_bracket=0;
@@ -4687,8 +4042,6 @@ yyreduce:
     break;
 
   case 293:
-
-/* Line 1806 of yacc.c  */
 #line 1077 "xi-grammar.y"
     { /*Stop grabbing CPROGRAM segments*/
 			in_bracket=0;
@@ -4702,50 +4055,36 @@ yyreduce:
     break;
 
   case 294:
-
-/* Line 1806 of yacc.c  */
 #line 1088 "xi-grammar.y"
     { (yyval.intval) = Parameter::ACCEL_BUFFER_TYPE_READONLY; }
     break;
 
   case 295:
-
-/* Line 1806 of yacc.c  */
 #line 1089 "xi-grammar.y"
     { (yyval.intval) = Parameter::ACCEL_BUFFER_TYPE_READWRITE; }
     break;
 
   case 296:
-
-/* Line 1806 of yacc.c  */
 #line 1090 "xi-grammar.y"
     { (yyval.intval) = Parameter::ACCEL_BUFFER_TYPE_WRITEONLY; }
     break;
 
   case 297:
-
-/* Line 1806 of yacc.c  */
 #line 1093 "xi-grammar.y"
     { (yyval.xstrptr) = new XStr((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 298:
-
-/* Line 1806 of yacc.c  */
 #line 1094 "xi-grammar.y"
     { (yyval.xstrptr) = new XStr(""); *((yyval.xstrptr)) << *((yyvsp[(1) - (4)].xstrptr)) << "->" << (yyvsp[(4) - (4)].strval); }
     break;
 
   case 299:
-
-/* Line 1806 of yacc.c  */
 #line 1095 "xi-grammar.y"
     { (yyval.xstrptr) = new XStr(""); *((yyval.xstrptr)) << *((yyvsp[(1) - (3)].xstrptr)) << "." << (yyvsp[(3) - (3)].strval); }
     break;
 
   case 300:
-
-/* Line 1806 of yacc.c  */
 #line 1097 "xi-grammar.y"
     {
                   (yyval.xstrptr) = new XStr("");
@@ -4756,8 +4095,6 @@ yyreduce:
     break;
 
   case 301:
-
-/* Line 1806 of yacc.c  */
 #line 1104 "xi-grammar.y"
     {
                   (yyval.xstrptr) = new XStr("");
@@ -4767,8 +4104,6 @@ yyreduce:
     break;
 
   case 302:
-
-/* Line 1806 of yacc.c  */
 #line 1110 "xi-grammar.y"
     {
                   (yyval.xstrptr) = new XStr("");
@@ -4779,8 +4114,6 @@ yyreduce:
     break;
 
   case 303:
-
-/* Line 1806 of yacc.c  */
 #line 1119 "xi-grammar.y"
     {
                   in_bracket = 0;
@@ -4789,8 +4122,6 @@ yyreduce:
     break;
 
   case 304:
-
-/* Line 1806 of yacc.c  */
 #line 1126 "xi-grammar.y"
     {
                   (yyval.pname) = new Parameter(lineno, (yyvsp[(3) - (7)].type), (yyvsp[(4) - (7)].strval));
@@ -4800,8 +4131,6 @@ yyreduce:
     break;
 
   case 305:
-
-/* Line 1806 of yacc.c  */
 #line 1132 "xi-grammar.y"
     {
 		  (yyval.pname) = new Parameter(lineno, (yyvsp[(1) - (5)].type), (yyvsp[(2) - (5)].strval));
@@ -4811,8 +4140,6 @@ yyreduce:
     break;
 
   case 306:
-
-/* Line 1806 of yacc.c  */
 #line 1138 "xi-grammar.y"
     {
                   (yyval.pname) = (yyvsp[(3) - (6)].pname);
@@ -4822,141 +4149,101 @@ yyreduce:
     break;
 
   case 307:
-
-/* Line 1806 of yacc.c  */
 #line 1146 "xi-grammar.y"
     { (yyval.plist) = new ParamList((yyvsp[(1) - (1)].pname)); }
     break;
 
   case 308:
-
-/* Line 1806 of yacc.c  */
 #line 1148 "xi-grammar.y"
     { (yyval.plist) = new ParamList((yyvsp[(1) - (3)].pname),(yyvsp[(3) - (3)].plist)); }
     break;
 
   case 309:
-
-/* Line 1806 of yacc.c  */
 #line 1152 "xi-grammar.y"
     { (yyval.plist) = new ParamList((yyvsp[(1) - (1)].pname)); }
     break;
 
   case 310:
-
-/* Line 1806 of yacc.c  */
 #line 1154 "xi-grammar.y"
     { (yyval.plist) = new ParamList((yyvsp[(1) - (3)].pname),(yyvsp[(3) - (3)].plist)); }
     break;
 
   case 311:
-
-/* Line 1806 of yacc.c  */
 #line 1158 "xi-grammar.y"
     { (yyval.plist) = (yyvsp[(2) - (3)].plist); }
     break;
 
   case 312:
-
-/* Line 1806 of yacc.c  */
 #line 1160 "xi-grammar.y"
     { (yyval.plist) = new ParamList(new Parameter(0, new BuiltinType("void"))); }
     break;
 
   case 313:
-
-/* Line 1806 of yacc.c  */
 #line 1164 "xi-grammar.y"
     { (yyval.plist) = (yyvsp[(2) - (3)].plist); }
     break;
 
   case 314:
-
-/* Line 1806 of yacc.c  */
 #line 1166 "xi-grammar.y"
     { (yyval.plist) = 0; }
     break;
 
   case 315:
-
-/* Line 1806 of yacc.c  */
 #line 1170 "xi-grammar.y"
     { (yyval.val) = 0; }
     break;
 
   case 316:
-
-/* Line 1806 of yacc.c  */
 #line 1172 "xi-grammar.y"
     { (yyval.val) = new Value((yyvsp[(3) - (3)].strval)); }
     break;
 
   case 317:
-
-/* Line 1806 of yacc.c  */
 #line 1176 "xi-grammar.y"
     { (yyval.sentry) = 0; }
     break;
 
   case 318:
-
-/* Line 1806 of yacc.c  */
 #line 1178 "xi-grammar.y"
     { (yyval.sentry) = new SdagEntryConstruct((yyvsp[(1) - (1)].sc)); }
     break;
 
   case 319:
-
-/* Line 1806 of yacc.c  */
 #line 1180 "xi-grammar.y"
     { (yyval.sentry) = new SdagEntryConstruct((yyvsp[(2) - (4)].slist)); }
     break;
 
   case 320:
-
-/* Line 1806 of yacc.c  */
 #line 1184 "xi-grammar.y"
     { (yyval.slist) = new SListConstruct((yyvsp[(1) - (1)].sc)); }
     break;
 
   case 321:
-
-/* Line 1806 of yacc.c  */
 #line 1186 "xi-grammar.y"
     { (yyval.slist) = new SListConstruct((yyvsp[(1) - (2)].sc), (yyvsp[(2) - (2)].slist));  }
     break;
 
   case 322:
-
-/* Line 1806 of yacc.c  */
 #line 1190 "xi-grammar.y"
     { (yyval.olist) = new OListConstruct((yyvsp[(1) - (1)].sc)); }
     break;
 
   case 323:
-
-/* Line 1806 of yacc.c  */
 #line 1192 "xi-grammar.y"
     { (yyval.olist) = new OListConstruct((yyvsp[(1) - (2)].sc), (yyvsp[(2) - (2)].slist)); }
     break;
 
   case 324:
-
-/* Line 1806 of yacc.c  */
 #line 1196 "xi-grammar.y"
     { (yyval.clist) = new CaseListConstruct((yyvsp[(1) - (1)].when)); }
     break;
 
   case 325:
-
-/* Line 1806 of yacc.c  */
 #line 1198 "xi-grammar.y"
     { (yyval.clist) = new CaseListConstruct((yyvsp[(1) - (2)].when), (yyvsp[(2) - (2)].clist)); }
     break;
 
   case 326:
-
-/* Line 1806 of yacc.c  */
 #line 1200 "xi-grammar.y"
     {
 		  ERROR("case blocks can only contain when clauses",
@@ -4966,220 +4253,158 @@ yyreduce:
     break;
 
   case 327:
-
-/* Line 1806 of yacc.c  */
 #line 1208 "xi-grammar.y"
     { (yyval.strval) = (yyvsp[(1) - (1)].strval); }
     break;
 
   case 328:
-
-/* Line 1806 of yacc.c  */
 #line 1210 "xi-grammar.y"
     { (yyval.strval) = 0; }
     break;
 
   case 329:
-
-/* Line 1806 of yacc.c  */
 #line 1214 "xi-grammar.y"
     { (yyval.when) = new WhenConstruct((yyvsp[(2) - (4)].entrylist), 0); }
     break;
 
   case 330:
-
-/* Line 1806 of yacc.c  */
 #line 1216 "xi-grammar.y"
     { (yyval.when) = new WhenConstruct((yyvsp[(2) - (3)].entrylist), (yyvsp[(3) - (3)].sc)); }
     break;
 
   case 331:
-
-/* Line 1806 of yacc.c  */
 #line 1218 "xi-grammar.y"
     { (yyval.when) = new WhenConstruct((yyvsp[(2) - (5)].entrylist), (yyvsp[(4) - (5)].slist)); }
     break;
 
   case 332:
-
-/* Line 1806 of yacc.c  */
 #line 1222 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 333:
-
-/* Line 1806 of yacc.c  */
 #line 1224 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 334:
-
-/* Line 1806 of yacc.c  */
 #line 1226 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 335:
-
-/* Line 1806 of yacc.c  */
 #line 1228 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 336:
-
-/* Line 1806 of yacc.c  */
 #line 1230 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 337:
-
-/* Line 1806 of yacc.c  */
 #line 1232 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 338:
-
-/* Line 1806 of yacc.c  */
 #line 1234 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 339:
-
-/* Line 1806 of yacc.c  */
 #line 1236 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 340:
-
-/* Line 1806 of yacc.c  */
 #line 1238 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 341:
-
-/* Line 1806 of yacc.c  */
 #line 1240 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 342:
-
-/* Line 1806 of yacc.c  */
 #line 1242 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 343:
-
-/* Line 1806 of yacc.c  */
 #line 1244 "xi-grammar.y"
     { (yyval.when) = 0; }
     break;
 
   case 344:
-
-/* Line 1806 of yacc.c  */
 #line 1248 "xi-grammar.y"
     { (yyval.sc) = new SerialConstruct((yyvsp[(4) - (6)].strval), (yyvsp[(2) - (6)].strval), (yylsp[(3) - (6)]).first_line); }
     break;
 
   case 345:
-
-/* Line 1806 of yacc.c  */
 #line 1250 "xi-grammar.y"
     { (yyval.sc) = new OverlapConstruct((yyvsp[(3) - (4)].olist)); }
     break;
 
   case 346:
-
-/* Line 1806 of yacc.c  */
 #line 1252 "xi-grammar.y"
     { (yyval.sc) = (yyvsp[(1) - (1)].when); }
     break;
 
   case 347:
-
-/* Line 1806 of yacc.c  */
 #line 1254 "xi-grammar.y"
     { (yyval.sc) = new CaseConstruct((yyvsp[(3) - (4)].clist)); }
     break;
 
   case 348:
-
-/* Line 1806 of yacc.c  */
 #line 1256 "xi-grammar.y"
     { (yyval.sc) = new ForConstruct((yyvsp[(3) - (11)].intexpr), (yyvsp[(5) - (11)].intexpr), (yyvsp[(7) - (11)].intexpr), (yyvsp[(10) - (11)].slist)); }
     break;
 
   case 349:
-
-/* Line 1806 of yacc.c  */
 #line 1258 "xi-grammar.y"
     { (yyval.sc) = new ForConstruct((yyvsp[(3) - (9)].intexpr), (yyvsp[(5) - (9)].intexpr), (yyvsp[(7) - (9)].intexpr), (yyvsp[(9) - (9)].sc)); }
     break;
 
   case 350:
-
-/* Line 1806 of yacc.c  */
 #line 1260 "xi-grammar.y"
     { (yyval.sc) = new ForallConstruct(new SdagConstruct(SIDENT, (yyvsp[(3) - (12)].strval)), (yyvsp[(6) - (12)].intexpr),
 		             (yyvsp[(8) - (12)].intexpr), (yyvsp[(10) - (12)].intexpr), (yyvsp[(12) - (12)].sc)); }
     break;
 
   case 351:
-
-/* Line 1806 of yacc.c  */
 #line 1263 "xi-grammar.y"
     { (yyval.sc) = new ForallConstruct(new SdagConstruct(SIDENT, (yyvsp[(3) - (14)].strval)), (yyvsp[(6) - (14)].intexpr),
 		             (yyvsp[(8) - (14)].intexpr), (yyvsp[(10) - (14)].intexpr), (yyvsp[(13) - (14)].slist)); }
     break;
 
   case 352:
-
-/* Line 1806 of yacc.c  */
 #line 1266 "xi-grammar.y"
     { (yyval.sc) = new IfConstruct((yyvsp[(3) - (6)].intexpr), (yyvsp[(5) - (6)].sc), (yyvsp[(6) - (6)].sc)); }
     break;
 
   case 353:
-
-/* Line 1806 of yacc.c  */
 #line 1268 "xi-grammar.y"
     { (yyval.sc) = new IfConstruct((yyvsp[(3) - (8)].intexpr), (yyvsp[(6) - (8)].slist), (yyvsp[(8) - (8)].sc)); }
     break;
 
   case 354:
-
-/* Line 1806 of yacc.c  */
 #line 1270 "xi-grammar.y"
     { (yyval.sc) = new WhileConstruct((yyvsp[(3) - (5)].intexpr), (yyvsp[(5) - (5)].sc)); }
     break;
 
   case 355:
-
-/* Line 1806 of yacc.c  */
 #line 1272 "xi-grammar.y"
     { (yyval.sc) = new WhileConstruct((yyvsp[(3) - (7)].intexpr), (yyvsp[(6) - (7)].slist)); }
     break;
 
   case 356:
-
-/* Line 1806 of yacc.c  */
 #line 1274 "xi-grammar.y"
     { (yyval.sc) = new SerialConstruct((yyvsp[(2) - (4)].strval), NULL, (yyloc).first_line); }
     break;
 
   case 357:
-
-/* Line 1806 of yacc.c  */
 #line 1276 "xi-grammar.y"
     {
 		  ERROR("unknown SDAG construct or malformed entry method declaration.\n"
@@ -5191,50 +4416,36 @@ yyreduce:
     break;
 
   case 358:
-
-/* Line 1806 of yacc.c  */
 #line 1286 "xi-grammar.y"
     { (yyval.sc) = 0; }
     break;
 
   case 359:
-
-/* Line 1806 of yacc.c  */
 #line 1288 "xi-grammar.y"
     { (yyval.sc) = new ElseConstruct((yyvsp[(2) - (2)].sc)); }
     break;
 
   case 360:
-
-/* Line 1806 of yacc.c  */
 #line 1290 "xi-grammar.y"
     { (yyval.sc) = new ElseConstruct((yyvsp[(3) - (4)].slist)); }
     break;
 
   case 361:
-
-/* Line 1806 of yacc.c  */
 #line 1294 "xi-grammar.y"
     { (yyval.intexpr) = new IntExprConstruct((yyvsp[(1) - (1)].strval)); }
     break;
 
   case 362:
-
-/* Line 1806 of yacc.c  */
 #line 1298 "xi-grammar.y"
     { in_int_expr = 0; (yyval.intval) = 0; }
     break;
 
   case 363:
-
-/* Line 1806 of yacc.c  */
 #line 1302 "xi-grammar.y"
     { in_int_expr = 1; (yyval.intval) = 0; }
     break;
 
   case 364:
-
-/* Line 1806 of yacc.c  */
 #line 1306 "xi-grammar.y"
     {
 		  (yyval.entry) = new Entry(lineno, 0, 0, (yyvsp[(1) - (2)].strval), (yyvsp[(2) - (2)].plist), 0, 0, 0, (yyloc).first_line, (yyloc).last_line);
@@ -5243,8 +4454,6 @@ yyreduce:
     break;
 
   case 365:
-
-/* Line 1806 of yacc.c  */
 #line 1311 "xi-grammar.y"
     {
 		  (yyval.entry) = new Entry(lineno, 0, 0, (yyvsp[(1) - (5)].strval), (yyvsp[(5) - (5)].plist), 0, 0, (yyvsp[(3) - (5)].strval), (yyloc).first_line, (yyloc).last_line);
@@ -5253,64 +4462,40 @@ yyreduce:
     break;
 
   case 366:
-
-/* Line 1806 of yacc.c  */
 #line 1318 "xi-grammar.y"
     { (yyval.entrylist) = new EntryList((yyvsp[(1) - (1)].entry)); }
     break;
 
   case 367:
-
-/* Line 1806 of yacc.c  */
 #line 1320 "xi-grammar.y"
     { (yyval.entrylist) = new EntryList((yyvsp[(1) - (3)].entry),(yyvsp[(3) - (3)].entrylist)); }
     break;
 
   case 368:
-
-/* Line 1806 of yacc.c  */
 #line 1324 "xi-grammar.y"
     { in_bracket=1; }
     break;
 
   case 369:
-
-/* Line 1806 of yacc.c  */
 #line 1327 "xi-grammar.y"
     { in_bracket=0; }
     break;
 
   case 370:
-
-/* Line 1806 of yacc.c  */
 #line 1331 "xi-grammar.y"
     { if (!macroDefined((yyvsp[(2) - (2)].strval), 1)) in_comment = 1; }
     break;
 
   case 371:
-
-/* Line 1806 of yacc.c  */
 #line 1335 "xi-grammar.y"
     { if (!macroDefined((yyvsp[(2) - (2)].strval), 0)) in_comment = 1; }
     break;
 
 
-
-/* Line 1806 of yacc.c  */
-#line 5301 "y.tab.c"
+/* Line 1267 of yacc.c.  */
+#line 4497 "y.tab.c"
       default: break;
     }
-  /* User semantic actions sometimes alter yychar, and that requires
-     that yytoken be updated with the new translation.  We take the
-     approach of translating immediately before every use of yytoken.
-     One alternative is translating here after every semantic action,
-     but that translation would be missed if the semantic action invokes
-     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
-     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
-     incorrect destructor might then be invoked immediately.  In the
-     case of YYERROR or YYBACKUP, subsequent parser actions might lead
-     to an incorrect destructor call or verbose syntax error message
-     before the lookahead is translated.  */
   YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
@@ -5339,10 +4524,6 @@ yyreduce:
 | yyerrlab -- here on detecting error |
 `------------------------------------*/
 yyerrlab:
-  /* Make sure we have latest lookahead translation.  See comments at
-     user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
@@ -5350,44 +4531,45 @@ yyerrlab:
 #if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
 #else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
       {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
+	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
+	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
+	  {
+	    YYSIZE_T yyalloc = 2 * yysize;
+	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
+	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
+	    if (yymsg != yymsgbuf)
+	      YYSTACK_FREE (yymsg);
+	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
+	    if (yymsg)
+	      yymsg_alloc = yyalloc;
+	    else
+	      {
+		yymsg = yymsgbuf;
+		yymsg_alloc = sizeof yymsgbuf;
+	      }
+	  }
+
+	if (0 < yysize && yysize <= yymsg_alloc)
+	  {
+	    (void) yysyntax_error (yymsg, yystate, yychar);
+	    yyerror (yymsg);
+	  }
+	else
+	  {
+	    yyerror (YY_("syntax error"));
+	    if (yysize != 0)
+	      goto yyexhaustedlab;
+	  }
       }
-# undef YYSYNTAX_ERROR
 #endif
     }
 
-  yyerror_range[1] = yylloc;
+  yyerror_range[0] = yylloc;
 
   if (yyerrstatus == 3)
     {
-      /* If just tried and failed to reuse lookahead token after an
+      /* If just tried and failed to reuse look-ahead token after an
 	 error, discard it.  */
 
       if (yychar <= YYEOF)
@@ -5404,7 +4586,7 @@ yyerrlab:
 	}
     }
 
-  /* Else will try to reuse lookahead token after shifting the error
+  /* Else will try to reuse look-ahead token after shifting the error
      token.  */
   goto yyerrlab1;
 
@@ -5420,7 +4602,7 @@ yyerrorlab:
   if (/*CONSTCOND*/ 0)
      goto yyerrorlab;
 
-  yyerror_range[1] = yylsp[1-yylen];
+  yyerror_range[0] = yylsp[1-yylen];
   /* Do not reclaim the symbols of the rule which action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
@@ -5439,7 +4621,7 @@ yyerrlab1:
   for (;;)
     {
       yyn = yypact[yystate];
-      if (!yypact_value_is_default (yyn))
+      if (yyn != YYPACT_NINF)
 	{
 	  yyn += YYTERROR;
 	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
@@ -5454,7 +4636,7 @@ yyerrlab1:
       if (yyssp == yyss)
 	YYABORT;
 
-      yyerror_range[1] = *yylsp;
+      yyerror_range[0] = *yylsp;
       yydestruct ("Error: popping",
 		  yystos[yystate], yyvsp, yylsp);
       YYPOPSTACK (1);
@@ -5462,12 +4644,15 @@ yyerrlab1:
       YY_STACK_PRINT (yyss, yyssp);
     }
 
+  if (yyn == YYFINAL)
+    YYACCEPT;
+
   *++yyvsp = yylval;
 
-  yyerror_range[2] = yylloc;
+  yyerror_range[1] = yylloc;
   /* Using YYLLOC is tempting, but would change the location of
-     the lookahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, yyerror_range, 2);
+     the look-ahead.  YYLOC is available though.  */
+  YYLLOC_DEFAULT (yyloc, (yyerror_range - 1), 2);
   *++yylsp = yyloc;
 
   /* Shift the error token.  */
@@ -5491,7 +4676,7 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#if !defined(yyoverflow) || YYERROR_VERBOSE
+#ifndef yyoverflow
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -5502,14 +4687,9 @@ yyexhaustedlab:
 #endif
 
 yyreturn:
-  if (yychar != YYEMPTY)
-    {
-      /* Make sure we have latest lookahead translation.  See comments at
-         user semantic actions for why this is necessary.  */
-      yytoken = YYTRANSLATE (yychar);
-      yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, &yylloc);
-    }
+  if (yychar != YYEOF && yychar != YYEMPTY)
+     yydestruct ("Cleanup: discarding lookahead",
+		 yytoken, &yylval, &yylloc);
   /* Do not reclaim the symbols of the rule which action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
@@ -5533,8 +4713,6 @@ yyreturn:
 }
 
 
-
-/* Line 2067 of yacc.c  */
 #line 1338 "xi-grammar.y"
 
 

--- a/src/xlat-i/xi-grammar.tab.h
+++ b/src/xlat-i/xi-grammar.tab.h
@@ -1,21 +1,24 @@
-/* A Bison parser, made by GNU Bison 2.5.  */
+/* A Bison parser, made by GNU Bison 2.3.  */
 
-/* Bison interface for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
-   
-   This program is free software: you can redistribute it and/or modify
+/* Skeleton interface for Bison's Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
+   Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-   
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -26,10 +29,9 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
-
 
 /* Tokens.  */
 #ifndef YYTOKENTYPE
@@ -190,11 +192,8 @@
 
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 typedef union YYSTYPE
-{
-
-/* Line 2068 of yacc.c  */
 #line 52 "xi-grammar.y"
-
+{
   AstChildren<Module> *modlist;
   Module *module;
   ConstructList *conslist;
@@ -236,15 +235,13 @@ typedef union YYSTYPE
   SdagEntryConstruct *sentry;
   XStr* xstrptr;
   AccelBlock* accelBlock;
-
-
-
-/* Line 2068 of yacc.c  */
-#line 244 "y.tab.h"
-} YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
+}
+/* Line 1529 of yacc.c.  */
+#line 241 "y.tab.h"
+	YYSTYPE;
 # define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
+# define YYSTYPE_IS_TRIVIAL 1
 #endif
 
 extern YYSTYPE yylval;
@@ -263,4 +260,3 @@ typedef struct YYLTYPE
 #endif
 
 extern YYLTYPE yylloc;
-

--- a/src/xlat-i/xi-grammar.y
+++ b/src/xlat-i/xi-grammar.y
@@ -391,7 +391,7 @@ TParamList	: TParam
 		;
 
 TParamEList	: /* Empty */
-		{ $$ = 0; }
+		{ $$ = new TParamList(0); }
 		| TParamList
 		{ $$ = $1; }
 		;


### PR DESCRIPTION
*Original author: Phil Miller*
*Original PR: https://charm.cs.illinois.edu/gerrit/3079*

---
CkArray::insertElement is no longer marked [inline] because it ends upcalling invokeEntry() on the underlying chare array elementconstructor as if it were [inline] as well, even though they're not somarked. As this happens, the resulting traces get quite screwedup. Moving away from that makes generating accurate traces easy, atthe expense of slightly higher overhead in dynamic element insertion.There's a possibility that some code relies on dynamically-insertedarray elements on the local PE being constructed inline. I don't thinkit's likely though.Change-Id: I3f7635837be81724af0e9dd1e9c98a31c0a5643b