### PR TITLE
AMPI #1214: turn on isomalloc/tlsglobals before calling user's justMigrated fn

### DIFF
--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1155,6 +1155,7 @@ class ampiParent : public CBase_ampiParent {
   MPI_MigrateFn userAboutToMigrateFn, userJustMigratedFn;
 
  public:
+  TCharmAPIRoutine *threadMigrationState;
   int ampiInitCallDone;
 
  public:

--- a/src/libs/ck-libs/tcharm/tcharm_impl.h
+++ b/src/libs/ck-libs/tcharm/tcharm_impl.h
@@ -276,6 +276,8 @@ class TCharmAPIRoutine {
 #endif
 
  public:
+	TCharmAPIRoutine(void) { }
+
 	// Entering Charm++ from user code
 	TCharmAPIRoutine(const char *routineName, const char *libraryName, bool actLikeMainThread_ = true)
 	  : actLikeMainThread(actLikeMainThread_)
@@ -349,6 +351,10 @@ class TCharmAPIRoutine {
 		_TRACE_BG_BEGIN_EXECUTE_NOMSG("user_code", &log, 0);
 		if (CmiMyPe() == pe) _TRACE_BG_ADD_BACKWARD_DEP(callEvent);
 #endif
+	}
+
+	void pup(PUP::er& p) {
+		pup_bytes(&p, this, sizeof(TCharmAPIRoutine));
 	}
 };
 


### PR DESCRIPTION
*Original PR: https://charm.cs.illinois.edu/gerrit/1865*

---
Change-Id: I3b509c801652fae3e628d1d71cb363b1654df568