### PR TITLE
AMPI cleanup recv code path by normalizing argument ordering

### DIFF
--- a/doc/ampi/manual.tex
+++ b/doc/ampi/manual.tex
@@ -1796,11 +1796,15 @@ for an Intel Omni-Path system:
 > build AMPI ofi-linux-x86_64 --with-production -DTCHARM_STACKSIZE_DEFAULT=16777216
 \end{alltt}
 
-The same can be done for AMPI's RDMA messaging threshold using \texttt{AMPI\_RDMA\_THRESHOLD\_DEFAULT} and,
-for messages sent within the same address space (ranks on the same worker thread or ranks
-on different worker threads in the same process in SMP builds), using \texttt{AMPI\_SMP\_RDMA\_THRESHOLD\_DEFAULT}.
-Contiguous messages with sizes larger than the threshold are sent via RDMA on communication layers that
-support this capability. You can also set the environment variables \texttt{AMPI\_RDMA\_THRESHOLD} and \texttt{AMPI\_SMP\_RDMA\_THRESHOLD}
+The same can be done for AMPI's various messaging protocols.
+For messages on the same PE or within the same Node (OS process), the threshold
+at which AMPI will use a rendezvous protocol to avoid making any intermediate copies
+can be set at build time with \texttt{AMPI\_PE\_LOCAL\_THRESHOLD\_DEFAULT} and
+\texttt{AMPI\_NODE\_LOCAL\_THRESHOLD\_DEFAULT}.
+AMPI also optimizes for large messages between processes using RDMA for contiguous messages
+on networks that support it. The RDMA threshold can be set using \texttt{AMPI\_RDMA\_THRESHOLD\_DEFAULT}.
+You can also set the environment variables \texttt{AMPI\_PE\_LOCAL\_THRESHOLD},
+\texttt{AMPI\_NODE\_LOCAL\_THRESHOLD}, and \texttt{AMPI\_RDMA\_THRESHOLD}.
 before running a job to override the default specified at build time.
 
 \section{Building and Running AMPI Programs}

--- a/doc/ampi/manual.tex
+++ b/doc/ampi/manual.tex
@@ -1797,15 +1797,20 @@ for an Intel Omni-Path system:
 \end{alltt}
 
 The same can be done for AMPI's various messaging protocols.
+All values passed to these size thresholds are in terms of Bytes.
 For messages on the same PE or within the same Node (OS process), the threshold
 at which AMPI will use a rendezvous protocol to avoid making any intermediate copies
 can be set at build time with \texttt{AMPI\_PE\_LOCAL\_THRESHOLD\_DEFAULT} and
 \texttt{AMPI\_NODE\_LOCAL\_THRESHOLD\_DEFAULT}.
 AMPI also optimizes for large messages between processes using RDMA for contiguous messages
 on networks that support it. The RDMA threshold can be set using \texttt{AMPI\_RDMA\_THRESHOLD\_DEFAULT}.
+Further, AMPI provides a mechanism to minimize its memory footprint. Users can set the
+\texttt{AMPI\_SSEND\_THRESHOLD\_DEFAULT}, which specifies that all messages with size greater than
+or equal to it will block on the matching receive operation. This can also be set to zero to test
+that an application will not deadlock based on the underlying message protocol and message matching semantics.
 You can also set the environment variables \texttt{AMPI\_PE\_LOCAL\_THRESHOLD},
-\texttt{AMPI\_NODE\_LOCAL\_THRESHOLD}, and \texttt{AMPI\_RDMA\_THRESHOLD}.
-before running a job to override the default specified at build time.
+\texttt{AMPI\_NODE\_LOCAL\_THRESHOLD}, \texttt{AMPI\_RDMA\_THRESHOLD}, and \texttt{AMPI\_SSEND\_THRESHOLD}.
+before running a job to override the defaults specified at build time.
 
 \section{Building and Running AMPI Programs}
 \subsection{Building AMPI Programs}

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -4718,11 +4718,11 @@ void ampi::sendrecv(const void *sbuf, int scount, MPI_Datatype stype, int dest, 
   reqs[1] = send(stag, getRank(), sbuf, scount, stype, dest, comm, I_SEND);
 
   if (sts == MPI_STATUS_IGNORE) {
-    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+    parent->waitall(2, reqs);
   }
   else {
     MPI_Status statuses[2];
-    MPI_Waitall(2, reqs, statuses);
+    parent->waitall(2, reqs, statuses);
     *sts = statuses[0];
   }
 }
@@ -4771,11 +4771,11 @@ void ampi::sendrecv_replace(void* buf, int count, MPI_Datatype datatype,
   reqs[1] = send(sendtag, getRank(), tmpBuf.data(), count, datatype, dest, comm, I_SEND);
 
   if (status == MPI_STATUS_IGNORE) {
-    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+    parent->waitall(2, reqs);
   }
   else {
     MPI_Status statuses[2];
-    MPI_Waitall(2, reqs, statuses);
+    parent->waitall(2, reqs, statuses);
     *status = statuses[0];
   }
 }
@@ -5899,7 +5899,7 @@ int SsendReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
 }
 
 int ATAReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+  parent->waitall(reqs.size(), reqs.data());
   reqs.clear();
   complete = true;
   return 0;
@@ -5984,16 +5984,12 @@ int ampiParent::wait(MPI_Request *request, MPI_Status *sts) noexcept
   return MPI_SUCCESS;
 }
 
-AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts[])
+int ampiParent::waitall(int count, MPI_Request request[], MPI_Status sts[]/*=MPI_STATUSES_IGNORE*/) noexcept
 {
-  AMPI_API("AMPI_Waitall");
-
-  checkRequests(count, request);
   if (count == 0) return MPI_SUCCESS;
 
-  ampiParent* pptr = getAmpiParent();
-  AmpiRequestList& reqs = pptr->getReqs();
-  CkAssert(pptr->numBlockedReqs == 0);
+  AmpiRequestList& reqs = getReqs();
+  CkAssert(numBlockedReqs == 0);
 
 #if AMPIMSGLOG
   if(msgLogRead){
@@ -6003,9 +5999,9 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
         continue;
       }
       AmpiRequest *waitReq = reqs[request[i]];
-      (*(pptr->fromPUPer))|(pptr->pupBytes);
-      PUParray(*(pptr->fromPUPer), (char *)(waitReq->buf), pptr->pupBytes);
-      PUParray(*(pptr->fromPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
+      (*fromPUPer)|pupBytes;
+      PUParray(*fromPUPer, (char *)(waitReq->buf), pupBytes);
+      PUParray(*fromPUPer, (char *)(&sts[i]), sizeof(MPI_Status));
     }
     return MPI_SUCCESS;
   }
@@ -6023,28 +6019,28 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
     }
     AmpiRequest& req = *reqs[request[i]];
     if (req.test()) {
-      req.wait(pptr, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
+      req.wait(this, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
       req.setBlocked(false);
 #if AMPIMSGLOG
-      if(msgLogWrite && record_msglog(pptr->thisIndex)){
-        (pptr->pupBytes) = getDDT()->getSize(req.type) * req.count;
-        (*(pptr->toPUPer))|(pptr->pupBytes);
-        PUParray(*(pptr->toPUPer), (char *)(req.buf), pptr->pupBytes);
-        PUParray(*(pptr->toPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
+      if(msgLogWrite && record_msglog(thisIndex)){
+        pupBytes = getDDT()->getSize(req.type) * req.count;
+        (*toPUPer)|pupBytes;
+        PUParray(*toPUPer, (char *)(req.buf), pupBytes);
+        PUParray(*toPUPer, (char *)(&sts[i]), sizeof(MPI_Status));
       }
 #endif
-      reqs.freeNonPersReq(pptr, request[i]);
+      reqs.freeNonPersReq(this, request[i]);
     }
     else {
       req.setBlocked(true);
-      pptr->numBlockedReqs++;
+      numBlockedReqs++;
     }
   }
 
   // If any requests are incomplete, block until all have been completed
-  if (pptr->numBlockedReqs > 0) {
-    getAmpiParent()->blockOnRecv();
-    pptr = getAmpiParent();
+  if (numBlockedReqs > 0) {
+    blockOnRecv();
+    ampiParent* pptr = getAmpiParent();
     reqs = pptr->getReqs(); //update pointer in case of migration while suspended
 
     for (int i=0; i<count; i++) {
@@ -6077,6 +6073,13 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
 #endif
 
   return MPI_SUCCESS;
+}
+
+AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts[])
+{
+  AMPI_API("AMPI_Waitall");
+  checkRequests(count, request);
+  return getAmpiParent()->waitall(count, request, sts);
 }
 
 AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_Status *sts)
@@ -8059,16 +8062,17 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
 
-  if(getAmpiParent()->isInter(comm))
+  if(pptr->isInter(comm))
     CkAbort("AMPI does not implement MPI_Alltoall for Inter-communicators!");
   if(ptr->getSize() == 1)
     return copyDatatype(sendtype,sendcount,recvtype,recvcount,sendbuf,recvbuf);
 
-  int itemsize = getDDT()->getSize(sendtype) * sendcount;
-  int itemextent = getDDT()->getExtent(sendtype) * sendcount;
-  int extent = getDDT()->getExtent(recvtype) * recvcount;
+  int itemsize = pptr->getDDT()->getSize(sendtype) * sendcount;
+  int itemextent = pptr->getDDT()->getExtent(sendtype) * sendcount;
+  int extent = pptr->getDDT()->getExtent(recvtype) * recvcount;
   int size = ptr->getSize();
   int rank = ptr->getRank();
 
@@ -8107,7 +8111,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*dst),
                                sendcount, sendtype, dst, comm, I_SEND);
     }
-    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(reqs.size(), reqs.data());
   }
   else if (itemsize <= AMPI_ALLTOALL_LONG_MSG) {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8124,7 +8128,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*dst),
                                       sendcount, sendtype, dst, comm, I_SEND);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      pptr->waitall(blockSize*2, reqs.data());
     }
   }
   else {
@@ -8238,7 +8242,8 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int size = ptr->getSize();
 
   if(getAmpiParent()->isInter(comm))
@@ -8278,7 +8283,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
                                sendcounts[dst], sendtype, dst, comm, I_SEND);
     }
-    MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(size*2, reqs.data());
   }
   else {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8295,7 +8300,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
                                       sendcounts[dst], sendtype, dst, comm);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      getAmpiParent()->waitall(blockSize*2, reqs.data());
     }
   }
 
@@ -8389,11 +8394,12 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int size = ptr->getSize();
   int rank = ptr->getRank();
 
-  if(getAmpiParent()->isInter(comm))
+  if(pptr->isInter(comm))
     CkAbort("AMPI does not implement MPI_Alltoallw for Inter-communicators!");
   if(size == 1)
     return copyDatatype(sendtypes[0],sendcounts[0],recvtypes[0],recvcounts[0],sendbuf,recvbuf);
@@ -8427,7 +8433,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+sdispls[dst],
                                sendcounts[dst], sendtypes[dst], dst, comm, I_SEND);
     }
-    MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(size*2, reqs.data());
   }
   else {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8444,7 +8450,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+sdispls[dst],
                                       sendcounts[dst], sendtypes[dst], dst, comm);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      getAmpiParent()->waitall(blockSize*2, reqs.data());
     }
   }
 
@@ -8536,7 +8542,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8558,9 +8565,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
                                       sendcount, sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoall, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -8641,7 +8646,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8663,9 +8669,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
                                       sendcounts[i], sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoallv, const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -8747,7 +8751,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8767,9 +8772,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
                                       sendcounts[i], sendtypes[i], neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoallw, const void* sendbuf, const int *sendcounts, const MPI_Aint *sdispls,
@@ -8849,7 +8852,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8870,9 +8874,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
                                       sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_allgather, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -8952,7 +8954,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8971,9 +8974,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
                                       sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -9083,7 +9084,7 @@ AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *d
   AMPI_API("AMPI_Comm_split");
   {
     ampiParent *pptr = getAmpiParent();
-    ampi *ptr = getAmpiInstance(src);
+    ampi *ptr = pptr->comm2ampi(src);
     if (pptr->isInter(src)) {
       ptr->split(color, key, dest, MPI_INTER);
     }
@@ -10289,9 +10290,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create, MPI_Comm comm_old, int n, const int so
     topo->setDestWeights(tmpWeights);
   }
 
-  MPI_Waitall(sends, requests.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return ptr->waitall(sends, requests.data());
 }
 
 AMPI_API_IMPL(int, MPI_Topo_test, MPI_Comm comm, int *status)

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -859,7 +859,6 @@ CtvDeclare(bool, ampiFinalized);
 CkpvDeclare(Builtin_kvs, bikvs);
 CkpvDeclare(int, ampiThreadLevel);
 CkpvDeclare(AmpiMsgPool, msgPool);
-CkpvDeclare(int, ssendInfoLen);
 
 CDECL
 long ampiCurrentStackUsage(void){
@@ -1012,12 +1011,7 @@ static void ampiProcInit() noexcept {
   CkpvAccess(bikvs) = Builtin_kvs();
 
   CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's, big enough for rendezvous messages
-  PUP::sizer pupSizer;
-  SsendInfo srcInfo;
-  pupSizer | srcInfo;
-  CkpvInitialize(int, ssendInfoLen);
-  CkpvAccess(ssendInfoLen) = pupSizer.size();
-  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, std::max(AMPI_POOLED_MSG_SIZE, CkpvAccess(ssendInfoLen)));
+  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, AMPI_POOLED_MSG_SIZE);
 
 #if AMPIMSGLOG
   char **argv=CkGetArgv();
@@ -2632,73 +2626,20 @@ ampi* ampi::blockOnRedn(AmpiRequest *req) noexcept {
   return dis;
 }
 
-// The recv'er invokes this on the sender when it has matched the sync message and
-// wants the sender to now send over the real message payload
-void ampi::ssendAck(int sreqIdx) noexcept
-{
-  MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d in ssendAck for reqIdx %d\n", parent->thisIndex, sreqIdx);
-  )
-
-  AmpiRequestList& reqs = getReqs();
-  SsendReq& sreq = (SsendReq&)*reqs[sreqIdx];
-  int destIdx = getIndexForRank(sreq.destRank);
-  CMK_REFNUM_TYPE seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
-
-#if AMPI_RDMA_IMPL
-  CkDDT_DataType* ddt = getDDT()->getType(sreq.type);
-  if (ddt->isContig()) {
-    int size = ddt->getSize(sreq.count);
-    if (size >= AMPI_RDMA_THRESHOLD) {
-      CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
-      completedSendCB.setRefnum(sreqIdx);
-      thisProxy[destIdx].genericRdma(CkSendBuffer(sreq.buf, completedSendCB), size, seq, sreq.tag, sreq.src);
-      return;
-    }
-  }
-#endif //AMPI_RDMA_IMPL
-
-  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm, seq));
-
-  sreq.complete = true;
-  handleBlockedReq(&sreq);
-  resumeThreadIfReady();
-}
-
 // Only "sync" messages (the first message in the rendezvous protocol)
-// from (I)Ssend are delivered here
+// are delivered here. We separate this only for visibility in Projections traces.
 void ampi::genericSync(AmpiMsg* msg) noexcept
 {
-  MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d sync arrival: tag=%d, src=%d, comm=%d, ssendReq=%d (seq %d) resumeOnRecv %d\n",
-             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), msg->getSsendReq(), msg->getSeq(), parent->resumeOnRecv);
-  )
   CkAssert(msg->isSsend());
-#if CMK_BIGSIM_CHARM
-  TRACE_BG_ADD_TAG("AMPI_generic");
-  msg->event = NULL;
-#endif
-
-  if(msg->getSeq() != 0) {
-    int seqIdx = msg->getSeqIdx();
-    if (oorder.put(seqIdx,msg) > 0) { // This message was in-order
-      inorder(msg);
-      // Sync messages don't immediately get processed:
-      // if in-order, the recv'er will invoke ampi::ssendAck to get the real payload back
-    }
-  } else { //Cross-world or system messages are unordered
-    inorder(msg);
-  }
-  // msg may be free'ed from calling inorder()
-
-  resumeThreadIfReady();
+  generic(msg);
 }
 
 void ampi::generic(AmpiMsg* msg) noexcept
 {
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d arrival: tag=%d, src=%d, comm=%d (seq %d) resumeOnRecv %d\n",
-             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), msg->getSeq(), parent->resumeOnRecv);
+    CkPrintf("AMPI vp %d %s arrival: tag=%d, src=%d, comm=%d (seq %d) resumeOnRecv %d\n",
+             thisIndex, (msg->isSsend()) ? "sync" : " ", msg->getTag(), msg->getSrcRank(),
+             getComm(), msg->getSeq(), parent->resumeOnRecv);
   )
 #if CMK_BIGSIM_CHARM
   TRACE_BG_ADD_TAG("AMPI_generic");
@@ -2708,11 +2649,11 @@ void ampi::generic(AmpiMsg* msg) noexcept
   if(msg->getSeq() != 0) {
     int seqIdx = msg->getSeqIdx();
     int n=oorder.put(seqIdx,msg);
-    if (n>0 && inorder(msg)) { // This message was in-order
-      if (n>1) { // It enables other, previously out-of-order messages
-        while((msg=oorder.getOutOfOrder(seqIdx))!=0) {
-          if (!inorder(msg)) break; // Returns false if msg is a sync message
-        }
+    if (n>0 && inorder(msg)) { // This message was in-order, and is not an incomplete sync message
+      for (int i=1; i<n; i++) { // It enables other, previously out-of-order messages
+        msg = oorder.getOutOfOrder(seqIdx);
+        CkAssert(msg);
+        if (!inorder(msg)) break; // Returns false if msg is an incomplete sync message
       }
     }
   } else { //Cross-world or system messages are unordered
@@ -2758,20 +2699,16 @@ bool ampi::inorder(AmpiMsg* msg) noexcept
   int srcRank = msg->getSrcRank();
   AmpiRequest* ireq = postedReqs.get(tag, srcRank);
   if (ireq) { // receive posted
-    bool resetNumBlockedReqs = false;
-    if (ireq->isBlocked() && parent->numBlockedReqs != 0) {
-      resetNumBlockedReqs = true;
-      parent->numBlockedReqs--;
+    if (msg->isSsend()) {
+      // Returns false if msg is an incomplete sync message
+      return ireq->receive(this, msg);
     }
-    if (!ireq->receive(this, msg)) { // Returns false if msg is a sync message
-      // Repost the req for the real message, undo any state changed by the SyncMsg
-      postedReqs.put(tag, srcRank, ireq);
-      if (resetNumBlockedReqs) {
-        parent->numBlockedReqs++;
-      }
-      return false;
+    else {
+      handleBlockedReq(ireq);
+      ireq->receive(this, msg);
     }
-  } else {
+  }
+  else {
     unexpectedMsgs.put(msg);
   }
   return true;
@@ -2798,11 +2735,10 @@ void ampi::genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
     int n = oorder.putIfInOrder(seqIdx, seq);
     if (n > 0) { // This message was in-order
       inorderRdma(buf, size, seq, tag, srcRank);
-      if (n > 1) { // It enables other, previously out-of-order messages
-        AmpiMsg *msg = NULL;
-        while ((msg = oorder.getOutOfOrder(seqIdx)) != 0) {
-          if (!inorder(msg)) break; // Returns false if msg is a sync message
-        }
+      for (int i=1; i<n; i++) { // It enables other, previously out-of-order messages
+        AmpiMsg* msg = oorder.getOutOfOrder(seqIdx);
+        CkAssert(msg);
+        if (!inorder(msg)) break; // Returns false if msg is an incomplete sync message
       }
     } else { // This message was out-of-order: stash it (as an AmpiMsg)
       AmpiMsg *msg = rdma2AmpiMsg(buf, size, seq, tag, srcRank);
@@ -2837,13 +2773,14 @@ void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
 // Callback signaling that the send buffer is now safe to re-use
 void ampi::completedSend(MPI_Request reqIdx) noexcept
 {
-   MSG_ORDER_DEBUG(
-     CkPrintf("[%d] send completed on vp %d, reqIdx = %d\n",
+  MSG_ORDER_DEBUG(
+     CkPrintf("[%d] VP %d in completedSend, reqIdx = %d\n",
               CkMyPe(), parent->thisIndex, reqIdx);
   )
 
   AmpiRequestList& reqList = getReqs();
   AmpiRequest& sreq = (*reqList[reqIdx]);
+  sreq.deregisterMem();
   sreq.complete = true;
 
   handleBlockedReq(&sreq);
@@ -2856,6 +2793,34 @@ void ampi::completedRdmaSend(CkDataMsg *msg) noexcept
   // refnum is the index into reqList for this SendReq
   int reqIdx = CkGetRefNum(msg);
   completedSend(reqIdx);
+  // [nokeep] entry method, so do not delete msg
+}
+
+void ampi::completedRecv(MPI_Request reqIdx) noexcept
+{
+  MSG_ORDER_DEBUG(
+    CkPrintf("[%d] VP %d in completedRecv, reqIdx = %d\n", CkMyPe(), parent->thisIndex, reqIdx);
+  )
+  AmpiRequestList& reqList = getReqs();
+  IReq& ireq = *((IReq*)(reqList[reqIdx]));
+  CkAssert(!ireq.complete);
+
+  if (ireq.systemBuf) {
+    // deserialize message from intermediate/system buffer into non-contiguous user buffer
+    processRdmaMsg(ireq.systemBuf, ireq.systemBufLen, ireq.buf, ireq.count, ireq.type);
+  }
+  ireq.deregisterMem();
+  ireq.complete = true;
+
+  handleBlockedReq(&ireq);
+  resumeThreadIfReady();
+}
+
+void ampi::completedRdmaRecv(CkDataMsg *msg) noexcept
+{
+  // refnum is the index into reqList for this IReq
+  int reqIdx = CkGetRefNum(msg);
+  completedRecv(reqIdx);
   // [nokeep] entry method, so do not delete msg
 }
 
@@ -2890,18 +2855,89 @@ AmpiMsg *ampi::makeBcastMsg(const void *buf,int count,MPI_Datatype type,MPI_Comm
   return msg;
 }
 
-// Create a AmpiMsg with a SsendInfo struct as the msg payload
-AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count,
-                           MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
+// Create an AmpiMsg with either an AmpiNcpyShmBuffer object or a CkNcpyBuffer object
+// as the msg payload based on the expected locality of the destination VP.
+// We optimize for PE/Process-local transfers by:
+// 1. Avoiding memory registration/pinning costs: some networks have high pinning/unpinning
+//    costs, which we want to avoid when unnecessary.
+// 2. Handling DDTs: instead of sending one message per contiguous
+//    memory region in a DDT, we handle non-contiguous messages with a single message.
+// Note: a recv'er can migrate out of the process that a sender thinks it is co-located
+//       within, meaning we have to handle that case in ampi::processSsendNcpyShmMsg().
+AmpiMsg *ampi::makeSyncMsg(int t,int sRank,const void *buf,int count,
+                           MPI_Datatype type,CProxy_ampi destProxy,
+                           int destIdx, int ssendReq,CMK_REFNUM_TYPE seq) noexcept
 {
   CkAssert(ssendReq >= 0);
+  if (destLikelyWithinProcess(destProxy, destIdx)) {
+    return makeNcpyShmMsg(t, sRank, buf, count, type, ssendReq, seq);
+  }
+  else {
+    return makeNcpyMsg(t, sRank, buf, count, type, ssendReq, seq);
+  }
+}
+
+// Create an AmpiMsg with an AmpiMsgType + AmpiNcpyShmBuffer object as the msg payload
+AmpiMsg* ampi::makeNcpyShmMsg(int t, int sRank, const void* buf, int count,
+                              MPI_Datatype type, int ssendReq, int seq) noexcept
+{
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
-  SsendInfo srcInfo(thisIndex, count, (char*)buf, ddt);
-  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, CkpvAccess(ssendInfoLen));
+  AmpiNcpyShmBuffer srcInfo(thisIndex, count, (char*)buf, ddt, ssendReq);
+  AmpiMsgType msgType = NCPY_SHM_MSG;
+  PUP::sizer pupSizer;
+  pupSizer | msgType;
+  pupSizer | srcInfo;
+  int srcInfoLen = pupSizer.size();
+
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, srcInfoLen);
   msg->setLength(len); // set AmpiMsg's length to be that of the real msg payload
+
   PUP::toMem pupPacker(msg->getData());
+  pupPacker | msgType;
   pupPacker | srcInfo;
+  return msg;
+}
+
+// Create an AmpiMsg with an AmpiMsgType + CkNcpyBuffer object as the msg payload
+AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
+                           MPI_Datatype type, int ssendReq, int seq) noexcept
+{
+  CkDDT_DataType *ddt = getDDT()->getType(type);
+  int len = ddt->getSize(count);
+  CkCallback sendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true /*inline*/);
+  sendCB.setRefnum(ssendReq);
+  SsendReq& req = *((SsendReq*)(getReqs()[ssendReq]));
+  req.srcInfo = new CkNcpyBuffer(buf, len, sendCB);
+
+  if (ddt->isContig()) {
+    req.srcInfo = new CkNcpyBuffer(buf, len, sendCB);
+  }
+  else {
+    // NOTE: if DDT could provide us with a list of pointers to contiguous chunks
+    //       of non-contiguous datatypes, we could send them in-place here. For
+    //       now we just copy into a contiguous system buffer and then send that.
+    char* sbuf = new char[len];
+    ddt->serialize((char*)buf, sbuf, count, len, PACK);
+    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    req.setSystemBuf(sbuf); // completedSend will need to free this
+    // NOTE: We could set 'req.complete = true' here, but then we'd
+    //       have to make sure req.systemBuf gets freed by someone else
+    //       in case 'req' is freed before the put() actually completes...
+  }
+
+  AmpiMsgType msgType = NCPY_MSG;
+  PUP::sizer pupSizer;
+  pupSizer | msgType;
+  pupSizer | (*req.srcInfo);
+  int srcInfoLen = pupSizer.size();
+
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, srcInfoLen);
+  msg->setLength(len); // set AmpiMsg's length to be that of the real msg payload
+
+  PUP::toMem pupPacker(msg->getData());
+  pupPacker | msgType;
+  pupPacker | (*req.srcInfo);
   return msg;
 }
 
@@ -3007,7 +3043,7 @@ void ampi::localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, in
     if (n > 1) { // It enables other, previously out-of-order messages
       AmpiMsg *msg = NULL;
       while ((msg = oorder.getOutOfOrder(seqIdx)) != 0) {
-        if (!inorder(msg)) break;
+        if (!inorder(msg)) break; // Returns false if msg is an incomplete sync message
       }
     }
   } else { // Cross-world or system messages are unordered
@@ -3019,9 +3055,9 @@ void ampi::localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, in
 }
 
 // Call genericRdma inline on the local destination object
-MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
-                               int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
-                               ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+MPI_Request ampi::sendLocalInOrderMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
+                                      int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
+                                      ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
   int seqIdx = srcRank;
 
@@ -3037,6 +3073,8 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
         destPtr->localInorder((char*)buf, size, seqIdx, seq, tag, srcRank, ireq);
       }
       else {
+        // NOTE: Intermediate copy here could be avoided if DDT
+        // could copy directly b/w two non-contiguous datatypes
         vector<char> sbuf(size);
         sddt->serialize((char*)buf, sbuf.data(), count, size, PACK); // intermediate copy for noncontig DDTs
         destPtr->localInorder(sbuf.data(), size, seqIdx, seq, tag, srcRank, ireq);
@@ -3044,7 +3082,7 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
 
       if (reqIdx != MPI_REQUEST_NULL) { // Persistent Send request
         AmpiRequestList& reqList = getReqs();
-        AmpiRequest& sreq = *(reqList[reqIdx]);
+        AmpiRequest& sreq = (*reqList[reqIdx]);
         CkAssert(sreq.isPersistent());
         sreq.complete = true;
         return reqIdx;
@@ -3070,11 +3108,11 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
                CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
     )
     if (reqIdx == MPI_REQUEST_NULL) {
-      reqIdx = postReq(parent->reqPool.newSsendReq(buf, count, type, destRank, tag, destComm, srcRank, getDDT(),
+      reqIdx = postReq(parent->reqPool.newSsendReq((void*)buf, count, type, destRank, tag, destComm, srcRank, getDDT(),
                                                    (sendType == BLOCKING_SSEND) ?
                                                    AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
     }
-    destPtr->genericSync(makeSyncMsg(destRank, tag, srcRank, buf, count, type, destComm, reqIdx, seq));
+    destPtr->genericSync(makeSyncMsg(tag, srcRank, buf, count, type, destPtr->thisProxy, destPtr->thisIndex, reqIdx, seq));
     return reqIdx;
   }
   else {
@@ -3084,23 +3122,23 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
 }
 
 MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                              int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxyElement_ampi destElem,
-                              AmpiSendType sendType, MPI_Request reqIdx) noexcept
+                              int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi destProxy,
+                              int destIdx, AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
   if (reqIdx == MPI_REQUEST_NULL) {
-    reqIdx = postReq(parent->reqPool.newSsendReq(buf, count, type, rank, t, destcomm, sRank, getDDT(),
+    reqIdx = postReq(parent->reqPool.newSsendReq((void*)buf, count, type, rank, t, destcomm, sRank, getDDT(),
                                                  (sendType == BLOCKING_SSEND) ?
                                                  AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
   }
   // All sync messages go thru ampi::genericSync (not generic or genericRdma)
 #if AMPI_LOCAL_IMPL
-  ampi* destPtr = destElem.ckLocal();
-  if (destPtr != nullptr) {
-    destPtr->genericSync(makeSyncMsg(rank, t, sRank, buf, count, type, destcomm, reqIdx, seq));
+  ampi* destPtr = destProxy[destIdx].ckLocal();
+  if (destPtr != NULL) {
+    destPtr->genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq));
   } else
 #endif
   {
-    destElem.genericSync(makeSyncMsg(rank, t, sRank, buf, count, type, destcomm, reqIdx, seq));
+    destProxy[destIdx].genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq));
   }
   return reqIdx;
 }
@@ -3130,22 +3168,25 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
 #if AMPI_LOCAL_IMPL
   ampi *destPtr = arrProxy[destIdx].ckLocal();
   if (destPtr != nullptr) {
-    return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
+    return sendLocalInOrderMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
   }
+#endif
+  if (
+#if AMPI_LOCAL_IMPL
+      (size >= AMPI_PE_LOCAL_THRESHOLD && destPtr != NULL) ||
+#endif
 #if CMK_SMP
-  if (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)) {
-    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
-  }
-#endif //CMK_SMP
-#endif //AMPI_LOCAL_IMPL
-  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
-    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
+      (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)) ||
+#endif
+      (sendType == BLOCKING_SSEND || sendType == I_SSEND))
+  {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy, destIdx, sendType, reqIdx);
   }
 #if AMPI_RDMA_IMPL
   if (ddt->isContig() && size >= AMPI_RDMA_THRESHOLD) {
     return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
   }
-#endif //AMPI_RDMA_IMPL
+#endif
   arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
   if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
     AmpiRequestList& reqList = parent->ampiReqs;
@@ -3157,68 +3198,167 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   return MPI_REQUEST_NULL;
 }
 
-// Ask the sender to send us the real message back
-void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
-{
-  int ssendReq = msg->getSsendReq();
-  CkAssert(ssendReq >= 0);
+// Invoked by recv'er when not co-located in the same process as sender.
+// Assumes that the recver has posted a contiguous buffer for the put() target,
+// but the send buffer may be non-contiguous.
+void ampi::requestPut(MPI_Request reqIdx, CkNcpyBuffer targetInfo) noexcept {
+  SsendReq& req = *((SsendReq*)(parent->ampiReqs[reqIdx]));
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d calling ssendAck with sreqIdx %d\n", parent->thisIndex, ssendReq);
+    CkPrintf("[%d] VP %d in requestPut, reqIdx = %d\n", CkMyPe(), parent->thisIndex, reqIdx);
   )
-  int srcIdx = getIndexForRank(msg->getSrcRank());
-  thisProxy[srcIdx].ssendAck(ssendReq);
+  CkDDT_DataType* sddt = getDDT()->getType(req.type);
+  CkCallback sendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true /*inline*/);
+  sendCB.setRefnum(reqIdx);
+
+  if (sddt->isContig()) {
+    req.srcInfo = new CkNcpyBuffer(req.buf, req.count, sendCB);
+  }
+  else {
+    int len = sddt->getSize(req.count);
+    char* sbuf = new char[len];
+    sddt->serialize((char*)req.buf, sbuf, req.count, len, PACK);
+    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    req.setSystemBuf(sbuf); // completedSend will need to free this
+    // NOTE: We could set 'req.statusIreq = true' here, but then we'd
+    // have to make sure systemBuf gets freed by someone in case the
+    // user tries to free 'req' before the put() actually completes...
+  }
+  req.srcInfo->put(targetInfo);
 }
 
-bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept
-{
-  SsendInfo srcInfo;
-  PUP::fromMem p(msg->getData());
-  p | srcInfo;
-#if AMPI_LOCAL_IMPL
+bool ampi::processSsendMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
+                           int count, MPI_Request req) noexcept {
+  CkAssert(req != MPI_REQUEST_NULL);
+  if (msg->isNcpyShmMsg()) {
+    return processSsendNcpyShmMsg(msg, buf, type, count, req);
+  }
+  else {
+    return processSsendNcpyMsg(msg, buf, type, count, req);
+  }
+}
+
+bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
+                                  int count, MPI_Request req) noexcept {
+  AmpiNcpyShmBuffer srcInfo;
+  msg->getNcpyShmBuffer(srcInfo);
+  CkDDT_DataType* rddt = getDDT()->getType(type);
+  int len = rddt->getSize(count);
+  IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
+  ireq.length = len;
+
   if (srcInfo.getNode() == CkMyNode()) {
-    *msgData = srcInfo.getBuf();
-    *msgLen = srcInfo.getDDT()->getSize(srcInfo.getCount());
+    // Sender and recver are co-located in the same process: use memcpy
+    MSG_ORDER_DEBUG(
+      CkPrintf("[%d] AMPI vp %d doing inline memcpy with req %d\n",
+               CkMyPe(), parent->thisIndex, req);
+    )
+    CkDDT_DataType* sddt = srcInfo.getDDT();
+    int msgCount = srcInfo.getCount();
+    int msgLen = sddt->getSize(msgCount);
+    char* msgData = srcInfo.getBuf();
+
+    // Handle non-contiguous send and/or recv datatypes
+    if (sddt->isContig()) {
+      rddt->serialize((char*)buf, msgData, count, msgLen, UNPACK);
+    }
+    else if (rddt->isContig()) {
+      sddt->serialize(msgData, (char*)buf, msgCount, msgLen, PACK);
+    }
+    else { // Both datatypes are non-contiguous
+      // NOTE: Intermediate copy here could be avoided if DDT
+      // could copy directly b/w two non-contiguous datatypes
+      vector<char> sbuf(msgLen);
+      sddt->serialize(msgData, sbuf.data(), msgCount, msgLen, PACK);
+      rddt->serialize((char*)buf, sbuf.data(), count, msgLen, UNPACK);
+    }
+
+    // complete the sender's SsendReq, inline if possible
     int srcIdx = srcInfo.getIdx();
     MPI_Request sreqIdx = msg->getSsendReq();
-    MSG_ORDER_DEBUG(
-      CkPrintf("AMPI vp %d in processSsendMsg, src is local so completing Ssend inline (req %d)\n", parent->thisIndex, sreqIdx);
-    )
+#if AMPI_LOCAL_IMPL
     ampi* srcPtr = thisProxy[srcIdx].ckLocal();
     if (srcPtr != NULL) {
       srcPtr->completedSend(sreqIdx);
     }
-    else {
+    else
+#endif
+    {
       thisProxy[srcIdx].completedSend(sreqIdx);
     }
+
+    // complete the recver's IReq inline
+    completedRecv(req);
     return true;
   }
-  else
-#endif //AMPI_LOCAL_IMPL
-  {
-    requestSsendMsg(msg);
+  else {
+    // Sender is no longer in the same process: request a put() of the data
+    MSG_ORDER_DEBUG(
+      CkPrintf("[%d] AMPI vp %d requesting rput with req %d\n",
+               CkMyPe(), parent->thisIndex, req);
+    )
+    CkCallback recvCB(CkIndex_ampi::completedRdmaRecv(NULL), thisProxy[thisIndex], true /*inline*/);
+    recvCB.setRefnum(req);
+    IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
+
+    if (rddt->isContig()) {
+      ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+    }
+    else {
+      // Allocate a contiguous intermediate buffer for the put(),
+      // and deserialize from that to the user's buffer in ampi::completedRecv
+      int slen = srcInfo.getLength();
+      char* sbuf = new char[slen];
+      ireq.setSystemBuf(sbuf, slen); // completedRecv will need to free this
+      ireq.targetInfo = new CkNcpyBuffer(sbuf, slen, recvCB);
+    }
+    thisProxy[srcInfo.getIdx()].requestPut(srcInfo.getSreqIdx(), *ireq.targetInfo);
     return false;
   }
 }
 
-bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
-{
-  char* msgData = msg->getData();
-  int msgLen = msg->getLength();
+bool ampi::processSsendNcpyMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept {
+  MSG_ORDER_DEBUG(
+    CkPrintf("[%d] AMPI vp %d performing get() with req %d\n",
+             CkMyPe(), parent->thisIndex, req);
+  )
+  CkNcpyBuffer srcInfo;
+  msg->getNcpyBuffer(srcInfo);
+  CkCallback recvCB(CkIndex_ampi::completedRdmaRecv(NULL), thisProxy[thisIndex], true /*inline*/);
+  recvCB.setRefnum(req);
+  CkDDT_DataType* ddt = getDDT()->getType(type);
+  int len = ddt->getSize(count);
+  IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
+  ireq.length = len;
 
-  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
-    if (!processSsendMsg(msg, &msgLen, &msgData)) {
-      return false;
-    }
+  if (ddt->isContig()) {
+    ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+  }
+  else {
+    char* sbuf = new char[len];
+    ireq.setSystemBuf(sbuf);
+    ireq.targetInfo = new CkNcpyBuffer(sbuf, len, recvCB);
+  }
+  ireq.targetInfo->get(srcInfo);
+  return ireq.complete; // did the get() complete inline (i.e. src is in same process as target)?
+}
+
+// Returns true if the message was processed,
+// false if it is a sync msg that could not yet be processed
+bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type,
+                          int count, MPI_Request req) noexcept
+{
+  if (msg->isSsend()) { // this is a sync msg, need to get the real msg data
+    return processSsendMsg(msg, buf, type, count, req);
   }
 
   CkDDT_DataType *ddt = getDDT()->getType(type);
-  ddt->serialize((char*)buf, msgData, count, msgLen, UNPACK);
+  ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), UNPACK);
   return true;
 }
 
 // RDMA version of ampi::processAmpiMsg
-void ampi::processRdmaMsg(const void *sbuf, int slength, int srank, void* rbuf,
-                          int rcount, MPI_Datatype rtype, MPI_Comm comm) noexcept
+void ampi::processRdmaMsg(const void *sbuf, int slength, void* rbuf,
+                          int rcount, MPI_Datatype rtype) noexcept
 {
   CkDDT_DataType *ddt = getDDT()->getType(rtype);
 
@@ -3379,62 +3519,12 @@ static inline bool handle_MPI_PROC_NULL(int src, MPI_Comm comm, MPI_Status* sts)
 
 int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm comm, MPI_Status *sts) noexcept
 {
-  MPI_Comm disComm = myComm.getComm();
-  if (handle_MPI_PROC_NULL(s, disComm, sts)) return 0;
-
-#if CMK_BIGSIM_CHARM
-   void *curLog; // store current log in timeline
-  _TRACE_BG_TLINE_END(&curLog);
-#if CMK_TRACE_IN_CHARM
-  if(CpvAccess(traceOn)) traceSuspend();
-#endif
-#endif
-
-  if (isInter()) {
-    s = myComm.getIndexForRemoteRank(s);
-  }
-
   MSG_ORDER_DEBUG(
     CkPrintf("AMPI vp %d blocking recv: tag=%d, src=%d, comm=%d\n",thisIndex,t,s,comm);
   )
-
-  ampi *dis = getAmpiInstance(disComm);
-  MPI_Status tmpStatus;
-  AmpiMsg* msg = unexpectedMsgs.get(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
-  if (msg) { // the matching message has already arrived
-    if (sts != MPI_STATUS_IGNORE) {
-      sts->MPI_SOURCE = msg->getSrcRank();
-      sts->MPI_TAG    = msg->getTag();
-      sts->MPI_COMM   = comm;
-      sts->MPI_LENGTH = msg->getLength();
-      sts->MPI_CANCEL = 0;
-    }
-#if CMK_BIGSIM_CHARM
-    TRACE_BG_AMPI_BREAK(thread->getThread(), "RECV_RESUME", NULL, 0, 0);
-    if (msg->eventPe == CkMyPe()) _TRACE_BG_ADD_BACKWARD_DEP(msg->event);
-#endif
-    if (processAmpiMsg(msg, buf, type, count)) {
-      CkpvAccess(msgPool).deleteAmpiMsg(msg);
-    }
-    else { // msg was a sync msg, so now block on the real msg
-      dis = blockOnIReq(buf, count, type, s, t, comm, sts);
-    }
-  }
-  else { // post a request and block until the matching message arrives
-    dis = blockOnIReq(buf, count, type, s, t, comm, sts);
-  }
-
-#if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
-  CpvAccess(_currentObj) = dis;
-  MSG_ORDER_DEBUG( printf("[%d] AMPI thread rescheduled  to Index %d buf %p src %d\n",CkMyPe(),dis->thisIndex,buf,s); )
-#endif
-#if CMK_BIGSIM_CHARM && CMK_TRACE_IN_CHARM
-  //Due to the reason mentioned the in the else-statement above, we need to
-  //use "dis" as "this" in the case of migration (or out-of-core execution in BigSim)
-  if(CpvAccess(traceOn)) CthTraceResume(dis->thread->getThread());
-#endif
-
-  return 0;
+  MPI_Request req;
+  irecv(buf, count, type, s, t, comm, &req);
+  return parent->wait(&req, sts);
 }
 
 void ampi::probe(int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
@@ -4588,15 +4678,24 @@ AMPI_API_IMPL(int, MPI_Mrecv, void* buf, int count, MPI_Datatype datatype, MPI_M
 #endif
 
   ampi *ptr = getAmpiInstance(comm);
-  if (status != MPI_STATUS_IGNORE) {
-    status->MPI_SOURCE = msg->getSrcRank();
-    status->MPI_TAG    = msg->getTag();
-    status->MPI_COMM   = comm;
-    status->MPI_LENGTH = msg->getLength();
-    status->MPI_CANCEL = 0;
+  if (msg->isSsend()) {
+    AmpiRequestList& reqs = ptr->getReqs();
+    IReq *newreq = parent->reqPool.newIReq(buf, count, datatype, src, tag, comm, getDDT());
+    MPI_Request request = reqs.insert(newreq);
+    newreq->receive(ptr, msg);
+    getAmpiParent()->wait(&request, status);
   }
-  ptr->processAmpiMsg(msg, buf, datatype, count);
-  CkpvAccess(msgPool).deleteAmpiMsg(msg);
+  else {
+    if (status != MPI_STATUS_IGNORE) {
+      status->MPI_SOURCE = msg->getSrcRank();
+      status->MPI_TAG    = msg->getTag();
+      status->MPI_COMM   = comm;
+      status->MPI_LENGTH = msg->getLength();
+      status->MPI_CANCEL = 0;
+    }
+    ptr->processAmpiMsg(msg, buf, datatype, count, MPI_REQUEST_NULL);
+    CkpvAccess(msgPool).deleteAmpiMsg(msg);
+  }
   *message = MPI_MESSAGE_NULL;
 
 #if AMPIMSGLOG
@@ -5826,20 +5925,24 @@ int GReq::wait(MPI_Status *sts) noexcept {
 AMPI_API_IMPL(int, MPI_Wait, MPI_Request *request, MPI_Status *sts)
 {
   AMPI_API("AMPI_Wait");
+  return getAmpiParent()->wait(request, sts);
+}
 
+int ampiParent::wait(MPI_Request *request, MPI_Status *sts) noexcept
+{
   if(*request == MPI_REQUEST_NULL){
     clearStatus(sts);
     return MPI_SUCCESS;
   }
   checkRequest(*request);
-  ampiParent* pptr = getAmpiParent();
-  AmpiRequestList& reqs = pptr->getReqs();
+  ampiParent* pptr = this;
+  AmpiRequestList& reqs = getReqs();
 
 #if AMPIMSGLOG
   if(msgLogRead){
-    (*(pptr->fromPUPer))|(pptr->pupBytes);
-    PUParray(*(pptr->fromPUPer), (char *)(reqs[*request]->buf), (pptr->pupBytes));
-    PUParray(*(pptr->fromPUPer), (char *)sts, sizeof(MPI_Status));
+    (*fromPUPer)|pupBytes;
+    PUParray(*fromPUPer, (char *)reqs[*request]->buf, pupBytes);
+    PUParray(*fromPUPer, (char *)sts, sizeof(MPI_Status));
     return MPI_SUCCESS;
   }
 #endif
@@ -5853,7 +5956,7 @@ AMPI_API_IMPL(int, MPI_Wait, MPI_Request *request, MPI_Status *sts)
              *request, reqs[*request], (int)(reqs[*request]->tag));
   AMPI_DEBUG("MPI_Wait: request=%d, reqs.size=%d, &reqs=%d\n",
              *request, reqs.size(), reqs);
-  CkAssert(pptr->numBlockedReqs == 0);
+  CkAssert(numBlockedReqs == 0);
   int waitResult = -1;
   do{
     AmpiRequest& waitReq = *reqs[*request];
@@ -5864,6 +5967,8 @@ AMPI_API_IMPL(int, MPI_Wait, MPI_Request *request, MPI_Status *sts)
     }
 #endif
   }while(waitResult==-1);
+  pptr = getAmpiParent(); // update pointer in case of migration while suspended
+  reqs = pptr->getReqs();
 
   CkAssert(pptr->numBlockedReqs == 0);
   AMPI_DEBUG("AMPI_Wait after calling wait, request=%d reqs[*request]=%p reqs[*request]->tag=%d\n",
@@ -5883,8 +5988,6 @@ AMPI_API_IMPL(int, MPI_Wait, MPI_Request *request, MPI_Status *sts)
 #endif
 
   reqs.freeNonPersReq(*request);
-
-  AMPI_DEBUG("End of AMPI_Wait\n");
 
   return MPI_SUCCESS;
 }
@@ -6205,7 +6308,7 @@ bool ATAReq::test(MPI_Status *sts/*=MPI_STATUS_IGNORE*/) noexcept {
 
 bool IReq::receive(ampi *ptr, AmpiMsg *msg) noexcept
 {
-  if (!ptr->processAmpiMsg(msg, buf, type, count)) { // Returns false if msg is a sync message
+  if (!ptr->processAmpiMsg(msg, buf, type, count, getReqIdx())) { // Returns false if msg is an incomplete sync message
     CkpvAccess(msgPool).deleteAmpiMsg(msg);
     return false;
   }
@@ -6225,7 +6328,7 @@ bool IReq::receive(ampi *ptr, AmpiMsg *msg) noexcept
 
 void IReq::receiveRdma(ampi *ptr, char *sbuf, int slength, int srcRank) noexcept
 {
-  ptr->processRdmaMsg(sbuf, slength, srcRank, buf, count, type, ptr->getComm());
+  ptr->processRdmaMsg(sbuf, slength, buf, count, type);
   complete = true;
   length = slength;
   comm = ptr->getComm();
@@ -7049,11 +7152,8 @@ void ampi::irecv(void *buf, int count, MPI_Datatype type, int src,
 #endif
 
   AmpiMsg* msg = unexpectedMsgs.get(tag, src);
-  // if msg has already arrived, do the receive right away
-  if (msg) {
-    if (!newreq->receive(this, msg)) { // Returns false if msg is a sync message
-      postedReqs.put(tag, src, newreq);
-    }
+  if (msg) { // if msg has already arrived, do the receive right away
+    newreq->receive(this, msg);
   }
   else { // ... otherwise post the receive
     postedReqs.put(newreq);

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -847,8 +847,10 @@ void AMPI_Setup_Switch(void) {
   }
 }
 
+int AMPI_LOCAL_THRESHOLD = AMPI_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
 int AMPI_SMP_RDMA_THRESHOLD = AMPI_SMP_RDMA_THRESHOLD_DEFAULT;
+
 static bool nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
 CtvDeclare(bool, ampiInitDone);
@@ -935,6 +937,16 @@ static void ampiNodeInit() noexcept
 
   /* read AMPI environment variables */
   char *value;
+  if ((value = getenv("AMPI_LOCAL_THRESHOLD"))) {
+    AMPI_LOCAL_THRESHOLD = atoi(value);
+    if (CkMyNode() == 0) {
+#if AMPI_LOCAL_IMPL
+      CkPrintf("AMPI> local messaging threshold is %d Bytes.\n", AMPI_LOCAL_THRESHOLD);
+#else
+      CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
+#endif
+    }
+  }
   bool rdmaSet = false;
   if ((value = getenv("AMPI_RDMA_THRESHOLD"))) {
     AMPI_RDMA_THRESHOLD = atoi(value);
@@ -2616,13 +2628,13 @@ void ampi::ssendAck(int sreqIdx) noexcept
   AmpiRequestList& reqs = getReqs();
   SsendReq& sreq = (SsendReq&)*reqs[sreqIdx];
   int destIdx = getIndexForRank(sreq.destRank);
+  CMK_REFNUM_TYPE seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
 
 #if AMPI_RDMA_IMPL
   CkDDT_DataType* ddt = getDDT()->getType(sreq.type);
   if (ddt->isContig()) {
     int size = ddt->getSize(sreq.count);
     if (size >= AMPI_RDMA_THRESHOLD) {
-      int seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
       CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
       completedSendCB.setRefnum(sreqIdx);
       thisProxy[destIdx].genericRdma(CkSendBuffer(sreq.buf, completedSendCB), size, seq, sreq.tag, sreq.src);
@@ -2631,7 +2643,7 @@ void ampi::ssendAck(int sreqIdx) noexcept
   }
 #endif //AMPI_RDMA_IMPL
 
-  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm));
+  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm, seq));
 
   sreq.complete = true;
   handleBlockedReq(&sreq);
@@ -2644,9 +2656,9 @@ void ampi::genericSync(AmpiMsg* msg) noexcept
 {
   MSG_ORDER_DEBUG(
     CkPrintf("AMPI vp %d sync arrival: tag=%d, src=%d, comm=%d, ssendReq=%d (seq %d) resumeOnRecv %d\n",
-             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), CkGetRefNum(msg), msg->getSeq(), parent->resumeOnRecv);
+             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), msg->getSsendReq(), msg->getSeq(), parent->resumeOnRecv);
   )
-  CkAssert(CkGetRefNum(msg));
+  CkAssert(msg->isSsend());
 #if CMK_BIGSIM_CHARM
   TRACE_BG_ADD_TAG("AMPI_generic");
   msg->event = NULL;
@@ -2654,8 +2666,7 @@ void ampi::genericSync(AmpiMsg* msg) noexcept
 
   if(msg->getSeq() != 0) {
     int seqIdx = msg->getSeqIdx();
-    int n=oorder.put(seqIdx,msg);
-    if (n>0) { // This message was in-order
+    if (oorder.put(seqIdx,msg) > 0) { // This message was in-order
       inorder(msg);
       // Sync messages don't immediately get processed:
       // if in-order, the recv'er will invoke ampi::ssendAck to get the real payload back
@@ -2682,8 +2693,7 @@ void ampi::generic(AmpiMsg* msg) noexcept
   if(msg->getSeq() != 0) {
     int seqIdx = msg->getSeqIdx();
     int n=oorder.put(seqIdx,msg);
-    if (n>0) { // This message was in-order
-      inorder(msg);
+    if (n>0 && inorder(msg)) { // This message was in-order
       if (n>1) { // It enables other, previously out-of-order messages
         while((msg=oorder.getOutOfOrder(seqIdx))!=0) {
           if (!inorder(msg)) break; // Returns false if msg is a sync message
@@ -2770,7 +2780,7 @@ void ampi::genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
 
   if (seq != 0) {
     int seqIdx = srcRank;
-    int n = oorder.isInOrder(seqIdx, seq);
+    int n = oorder.putIfInOrder(seqIdx, seq);
     if (n > 0) { // This message was in-order
       inorderRdma(buf, size, seq, tag, srcRank);
       if (n > 1) { // It enables other, previously out-of-order messages
@@ -2809,24 +2819,29 @@ void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
   }
 }
 
-// Callback from ampi::genericRdma() signaling that the send buffer is now safe to re-use
+// Callback signaling that the send buffer is now safe to re-use
+void ampi::completedSend(MPI_Request reqIdx) noexcept
+{
+   MSG_ORDER_DEBUG(
+     CkPrintf("[%d] send completed on vp %d, reqIdx = %d\n",
+              CkMyPe(), parent->thisIndex, reqIdx);
+  )
+
+  AmpiRequestList& reqList = getReqs();
+  AmpiRequest& sreq = (*reqList[reqIdx]);
+  sreq.complete = true;
+
+  handleBlockedReq(&sreq);
+  resumeThreadIfReady();
+}
+
+// Callback signaling that the send buffer is now safe to re-use
 void ampi::completedRdmaSend(CkDataMsg *msg) noexcept
 {
   // refnum is the index into reqList for this SendReq
   int reqIdx = CkGetRefNum(msg);
-
-  MSG_ORDER_DEBUG(
-    CkPrintf("[%d] in ampi::completedRdmaSend on index %d, reqIdx = %d\n",
-             CkMyPe(), parent->thisIndex, reqIdx);
-  )
-
-  AmpiRequestList& reqList = getReqs();
-  AmpiRequest* sreq = reqList[reqIdx];
-  sreq->complete = true;
-
-  handleBlockedReq(sreq);
-  resumeThreadIfReady();
-  // CkDataMsg is allocated & freed by the runtime, so do not delete msg
+  completedSend(reqIdx);
+  // [nokeep] entry method, so do not delete msg
 }
 
 void handle_MPI_BOTTOM(void* &buf, MPI_Datatype type) noexcept
@@ -2875,9 +2890,15 @@ AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int coun
 AmpiMsg *ampi::makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
                            MPI_Datatype type,MPI_Comm destcomm) noexcept
 {
+  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
+  return makeAmpiMsg(destRank, t, sRank, buf, count, type, destcomm, seq);
+}
+
+AmpiMsg *ampi::makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
+                           MPI_Datatype type,MPI_Comm destcomm,CMK_REFNUM_TYPE seq) noexcept
+{
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
   AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, MPI_REQUEST_NULL, t, sRank, len);
   ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), PACK);
   return msg;
@@ -2937,10 +2958,9 @@ CMK_REFNUM_TYPE ampi::getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcep
 }
 
 MPI_Request ampi::sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                              int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, MPI_Request reqIdx) noexcept
+                              int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
+                              MPI_Request reqIdx) noexcept
 {
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
-
   // Set up a SendReq to track completion of the send buffer
   if (reqIdx == MPI_REQUEST_NULL) {
     reqIdx = postReq(parent->reqPool.newSendReq(type, destcomm, getDDT()));
@@ -2952,30 +2972,103 @@ MPI_Request ampi::sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_D
   return reqIdx;
 }
 
-// Call genericRdma inline on the local destination object
-MPI_Request ampi::sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destRank,
-                               MPI_Comm destcomm, ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+// Local version of ampi::generic but assumes msg is in-order & ireq is the matching recv req
+void ampi::localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, int tag,
+                        int srcRank, IReq* ireq) noexcept
 {
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
+  MSG_ORDER_DEBUG(
+    CkPrintf("[%d] in ampi::localInorder on index %d, size=%d, seq=%d, srcRank=%d, tag=%d, comm=%d\n",
+             CkMyPe(), getIndexForRank(getRank()), size, seq, srcRank, tag, getComm());
+  )
 
-  destPtr->genericRdma((char*)buf, size, seq, t, sRank);
-
-  if (sendType == BLOCKING_SEND) {
-    return MPI_REQUEST_NULL;
+  if (seq != 0) {
+    int n = oorder.putIfInOrder(seqIdx, seq);
+    CkAssert(n > 0); // This message must be in-order
+    handleBlockedReq(ireq);
+    ireq->receiveRdma(this, buf, size, srcRank);
+    if (n > 1) { // It enables other, previously out-of-order messages
+      AmpiMsg *msg = NULL;
+      while ((msg = oorder.getOutOfOrder(seqIdx)) != 0) {
+        if (!inorder(msg)) break;
+      }
+    }
+  } else { // Cross-world or system messages are unordered
+    handleBlockedReq(ireq);
+    ireq->receiveRdma(this, buf, size, srcRank);
   }
-  else if (reqIdx != MPI_REQUEST_NULL) {
+
+  resumeThreadIfReady();
+}
+
+// Call genericRdma inline on the local destination object
+MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
+                               int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
+                               ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+{
+  int seqIdx = srcRank;
+
+  if (seq == 0 || destPtr->isInOrder(seqIdx, seq)) {
+    IReq* ireq = (IReq*)destPtr->postedReqs.get(tag, srcRank);
+    if (ireq != nullptr) { // Found a matching preposted request in the destination rank's queue
+      MSG_ORDER_DEBUG(
+        CkPrintf("[%d] AMPI vp %d sending local, in-order, matched msg inline to vp %d\n",
+                 CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
+      )
+      CkDDT_DataType* sddt = getDDT()->getType(type);
+      if (sddt->isContig()) {
+        destPtr->localInorder((char*)buf, size, seqIdx, seq, tag, srcRank, ireq);
+      }
+      else {
+        vector<char> sbuf(size);
+        sddt->serialize((char*)buf, sbuf.data(), count, size, PACK); // intermediate copy for noncontig DDTs
+        destPtr->localInorder(sbuf.data(), size, seqIdx, seq, tag, srcRank, ireq);
+      }
+
+      if (reqIdx != MPI_REQUEST_NULL) { // Persistent Send request
+        AmpiRequestList& reqList = getReqs();
+        AmpiRequest& sreq = *(reqList[reqIdx]);
+        CkAssert(sreq.isPersistent());
+        sreq.complete = true;
+        return reqIdx;
+      }
+      else if (sendType == BLOCKING_SEND || sendType == BLOCKING_SSEND) {
+        return MPI_REQUEST_NULL;
+      }
+      else if (sendType == I_SEND || sendType == BLOCKING_SEND) {
+        return postReq(parent->reqPool.newSendReq(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
+      }
+      else {
+        CkAssert(sendType == I_SSEND);
+        return postReq(parent->reqPool.newSsendReq(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
+      }
+    }
+  }
+
+  if (size >= AMPI_LOCAL_THRESHOLD ||
+     (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
+    // Block on the matching request to avoid making an intermediate copy
+    MSG_ORDER_DEBUG(
+      CkPrintf("[%d] AMPI vp %d sending local, out-of-order/unexpected msg inline using a Sync send from to vp %d\n",
+               CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
+    )
+    if (reqIdx == MPI_REQUEST_NULL) {
+      reqIdx = postReq(parent->reqPool.newSsendReq(buf, count, type, destRank, tag, destComm, srcRank, getDDT(),
+                                                   (sendType == BLOCKING_SSEND) ?
+                                                   AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
+    }
+    destPtr->genericSync(makeSyncMsg(destRank, tag, srcRank, buf, count, type, destComm, reqIdx, seq));
     return reqIdx;
   }
-  else { // SendReq is pre-completed since we directly copied the send buffer
-    return postReq(parent->reqPool.newSendReq(type, destcomm, getDDT(), AMPI_REQ_COMPLETED));
+  else {
+    destPtr->generic(makeAmpiMsg(destRank, tag, srcRank, buf, count, type, destComm, seq));
+    return MPI_REQUEST_NULL;
   }
 }
 
 MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                              int rank, MPI_Comm destcomm, CProxyElement_ampi destElem,
+                              int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxyElement_ampi destElem,
                               AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
-  int seq = getSeqNo(rank, destcomm, t);
   if (reqIdx == MPI_REQUEST_NULL) {
     reqIdx = postReq(parent->reqPool.newSsendReq(buf, count, type, rank, t, destcomm, sRank, getDDT(),
                                                  (sendType == BLOCKING_SSEND) ?
@@ -3008,47 +3101,40 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   } else {
     destIdx = dest.getIndexForRank(rank);
   }
+  CMK_REFNUM_TYPE seq = getSeqNo(rank, destcomm, t);
 
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,destIdx);
+    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d, seq=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,seq,destIdx);
   )
 
-  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
-    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, arrProxy[destIdx], sendType, reqIdx);
-  }
-  ampi *destPtr = arrProxy[destIdx].ckLocal();
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int size = ddt->getSize(count);
-  if (ddt->isContig()) {
 #if AMPI_LOCAL_IMPL
-    if (destPtr != NULL) {
-      return sendLocalMsg(t, sRank, buf, size, type, rank, destcomm, destPtr, sendType, reqIdx);
-    }
+  ampi *destPtr = arrProxy[destIdx].ckLocal();
+  if (destPtr != nullptr) {
+    return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
+  }
 #endif
+  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
+  }
 #if AMPI_RDMA_IMPL
-    if (size >= AMPI_RDMA_THRESHOLD ||
-       (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)))
-    {
-      return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, arrProxy, reqIdx);
-    }
-#endif
-  }
-#if AMPI_LOCAL_IMPL
-  if (destPtr != NULL) {
-    destPtr->generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
-    return MPI_REQUEST_NULL;
-  } else
-#endif
+  if (ddt->isContig() &&
+      (size >= AMPI_RDMA_THRESHOLD ||
+      (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx))))
   {
-    arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
-    if (reqIdx != MPI_REQUEST_NULL) {
-      AmpiRequestList& reqList = parent->ampiReqs;
-      AmpiRequest& sreq = (*reqList[reqIdx]);
-      sreq.complete = true;
-      return reqIdx;
-    }
-    return MPI_REQUEST_NULL;
+    return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
   }
+#endif
+  arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
+  if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
+    AmpiRequestList& reqList = parent->ampiReqs;
+    AmpiRequest& sreq = (*reqList[reqIdx]);
+    CkAssert(sreq.isPersistent());
+    sreq.complete = true;
+    return reqIdx;
+  }
+  return MPI_REQUEST_NULL;
 }
 
 // Ask the sender to send us the real message back
@@ -3063,15 +3149,45 @@ void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
   thisProxy[srcIdx].ssendAck(ssendReq);
 }
 
-bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
-{
-  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
+bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept {
+  int srcRank = msg->getSrcRank();
+  int srcIdx = getIndexForRank(srcRank);
+#if AMPI_LOCAL_IMPL
+  ampi* srcPtr = thisProxy[srcIdx].ckLocal();
+  if (srcPtr != NULL) {
+    MPI_Request sreqIdx = msg->getSsendReq();
+    ampiParent* srcParent = srcPtr->parent;
+    AmpiRequestList& reqs = srcParent->ampiReqs;
+    AmpiRequest& sreq = *(reqs[sreqIdx]);
+    *msgData = (char*)sreq.buf;
+    *msgLen = srcParent->myDDT.getSize(sreq.type) * sreq.count;
+    MSG_ORDER_DEBUG(
+      CkPrintf("AMPI vp %d in processSsendMsg, src is local so completing Ssend inline (req %d)\n", parent->thisIndex, sreqIdx);
+    )
+    srcPtr->completedSend(sreqIdx);
+    return true;
+  }
+  else
+#endif
+  {
     requestSsendMsg(msg);
     return false;
   }
+}
+
+bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
+{
+  char* msgData = msg->getData();
+  int msgLen = msg->getLength();
+
+  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
+    if (!processSsendMsg(msg, &msgLen, &msgData)) {
+      return false;
+    }
+  }
 
   CkDDT_DataType *ddt = getDDT()->getType(type);
-  ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), UNPACK);
+  ddt->serialize((char*)buf, msgData, count, msgLen, UNPACK);
   return true;
 }
 

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -43,10 +43,10 @@ module ampi {
     entry EXPEDITED_REDN void allInitDone(void);
     entry EXPEDITED void setInitDoneFlag();
     entry EXPEDITED void unblock(void);
-    entry EXPEDITED void ssend_ack(int);
+    entry EXPEDITED void ssendAck(int sreqIdx);
+    entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
-    entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag,
-                                     int srcRank, MPI_Comm destcomm, int ssendReq);
+    entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -47,6 +47,7 @@ module ampi {
     entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
     entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
+    entry EXPEDITED void completedSend(int sreqIdx);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -43,12 +43,13 @@ module ampi {
     entry EXPEDITED_REDN void allInitDone(void);
     entry EXPEDITED void setInitDoneFlag();
     entry EXPEDITED void unblock(void);
-    entry EXPEDITED void ssendAck(int sreqIdx);
     entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
     entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
     entry EXPEDITED void completedSend(int sreqIdx);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
+    entry EXPEDITED_NOKEEP void completedRdmaRecv(CkDataMsg *msg);
+    entry EXPEDITED void requestPut(MPI_Request req, CkNcpyBuffer targetInfo);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);
     entry EXPEDITED_NOKEEP void rednResult(CkReductionMsg *msg);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -14,7 +14,6 @@
 #define WIN_ERROR   (-1)
 
 extern int AMPI_RDMA_THRESHOLD;
-extern int AMPI_SMP_RDMA_THRESHOLD;
 
 win_obj::win_obj() noexcept {
   baseAddr = NULL;
@@ -221,9 +220,7 @@ int ampi::winPut(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank
                             targcnt, targtype, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newSendReq(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -408,9 +405,7 @@ int ampi::winAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, i
                                    targcnt, targtype, op, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (ddt->isContig() && orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newSendReq(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -473,9 +468,7 @@ int ampi::winGetAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype
       return MPI_SUCCESS;
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newSendReq(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -1131,7 +1131,7 @@ AMPI_API_IMPL(int, MPI_Win_start, MPI_Group group, int assertion, MPI_Win win)
   for (int i=0; i<subsetGroupRanks.size(); i++) {
     if (subsetGroupRanks[i] != MPI_UNDEFINED) {
       subsetGroupRanks[actualRanks++] = i;
-      ptr->recv(MPI_EPOCH_START_TAG, subsetGroupRanks[actualRanks-1], NULL, 0, MPI_INT, winStruct->comm, MPI_STATUS_IGNORE);
+      ptr->recv(NULL, 0, MPI_INT, subsetGroupRanks[actualRanks-1], MPI_EPOCH_START_TAG, winStruct->comm, MPI_STATUS_IGNORE);
     }
   }
 

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -1062,7 +1062,7 @@ AMPI_API_IMPL(int, MPI_Win_post, MPI_Group group, int assertion, MPI_Win win)
   for (int i=0; i<subsetGroupRanks.size(); i++) { // If subsetGroupRanks is large, multicast would be more efficient
     if (subsetGroupRanks[i] != MPI_UNDEFINED) {
       subsetGroupRanks[actualRanks++] = i;
-      ptr->send(MPI_EPOCH_START_TAG, ptr->getRank(), NULL, 0, MPI_INT, subsetGroupRanks[actualRanks-1], winStruct->comm);
+      ptr->send(NULL, 0, MPI_INT, subsetGroupRanks[actualRanks-1], MPI_EPOCH_START_TAG, winStruct->comm);
     }
   }
 
@@ -1158,7 +1158,7 @@ AMPI_API_IMPL(int, MPI_Win_complete, MPI_Win win)
   ampi *ptr = getAmpiInstance(winStruct->comm);
 
   for (int i=0; i<accessGroupRanks.size(); i++) {
-    ptr->send(MPI_EPOCH_END_TAG, ptr->getRank(), NULL, 0, MPI_INT, accessGroupRanks[i], winStruct->comm);
+    ptr->send(NULL, 0, MPI_INT, accessGroupRanks[i], MPI_EPOCH_END_TAG, winStruct->comm);
   }
   winStruct->clearEpochAccess();
 

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -228,8 +228,8 @@ int ampi::winPut(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank
       completedSendCB.setRefnum(req);
       thisProxy[rank].winRemotePut(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt, orgtype,
                                    targdisp, targcnt, targtype, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {
@@ -413,8 +413,8 @@ int ampi::winAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, i
       completedSendCB.setRefnum(req);
       thisProxy[rank].winRemoteAccumulate(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt,
                                           orgtype, targdisp, targcnt, targtype,  op, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {
@@ -476,8 +476,8 @@ int ampi::winGetAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype
       completedSendCB.setRefnum(req);
       msg = thisProxy[rank].winRemoteGetAccumulate(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt,
                                                    orgtype, targdisp, targcnt, targtype, op, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -119,10 +119,9 @@ class fromzDisk : public zdisk {
 #define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 16384
 #endif
 
-/* AMPI uses RDMA sends if BigSim is not being used and the underlying comm
- * layer supports it (except for GNI, which has experimental RDMA support). */
+/* AMPI uses RDMA sends if BigSim is not being used. */
 #ifndef AMPI_RDMA_IMPL
-#define AMPI_RDMA_IMPL ( !CMK_BIGSIM_CHARM && CMK_ONESIDED_IMPL && !CMK_CONVERSE_UGNI )
+#define AMPI_RDMA_IMPL !CMK_BIGSIM_CHARM
 #endif
 
 /* contiguous messages larger than or equal to this threshold are sent via RDMA */
@@ -282,28 +281,38 @@ class AmpiOpHeader {
 };
 
 /*
- * For within-node Ssend's: used in ampi::processSsendMsg()
+ * For within-process Ssend's, we use this in place of a CkNcpyBuffer object in the
+ * AmpiMsg's data. This allows us to handle non-contiguous DDTs directly and to avoid
+ * the cost of pinning memory when doing Ssend's on the same PE and in the same process.
  */
-class SsendInfo {
+class AmpiNcpyShmBuffer {
  private:
   int node;
   int idx;
   int count;
+  int length;
   char* buf;
   CkDDT_DataType* ddt;
+  MPI_Request sreq;
 
  public:
-  SsendInfo() = default;
-  SsendInfo(int idx_, int count_, char* buf_, CkDDT_DataType* ddt_) noexcept :
-    node(CkMyNode()), idx(idx_), count(count_), buf(buf_), ddt(ddt_) {}
-  ~SsendInfo() {}
+  AmpiNcpyShmBuffer() = default;
+  AmpiNcpyShmBuffer(int idx_, int count_, char* buf_, CkDDT_DataType* ddt_, MPI_Request sreq_) noexcept
+    : idx(idx_), count(count_), buf(buf_), ddt(ddt_), sreq(sreq_)
+  {
+    node = CkMyNode();
+    length = ddt_->getSize(count_);
+  }
+  ~AmpiNcpyShmBuffer() = default;
   inline int getNode() const noexcept { return node; }
   inline int getIdx() const noexcept { return idx; }
   inline int getCount() const noexcept { return count; }
+  inline int getLength() const noexcept { return length; }
+  inline int getSreqIdx() const noexcept { return sreq; }
   inline char* getBuf() const noexcept { CkAssert(node == CkMyNode()); return buf; }
   inline CkDDT_DataType* getDDT() const noexcept { CkAssert(node == CkMyNode()); return ddt; }
 };
-PUPbytes(SsendInfo) // PUP as bytes b/c buf & ddt are only meant to be accessed from within shared memory
+PUPbytes(AmpiNcpyShmBuffer) // PUP as bytes b/c buf & ddt are only meant to be accessed from within shared memory
 
 //------------------- added by YAN for one-sided communication -----------
 /* the index is unique within a communicator */
@@ -1177,6 +1186,12 @@ class AmpiRequest {
   virtual void setPersistent(bool p) noexcept {}
   virtual bool isPersistent() const noexcept { return false; }
 
+  /// Deregister memory from a get/put
+  virtual void deregisterMem() { }
+
+  /// Set an intermediate/system buffer that a message will be serialized thru
+  virtual void setSystemBuf(void* buf_, int len=0) { }
+
   /// Receive an AmpiMsg
   /// Returns true if the msg payload is recv'ed, otherwise return false
   /// (if the msg is a sync msg, it can't be recv'ed until the caller
@@ -1257,9 +1272,12 @@ class AmpiRequest {
 
 class IReq final : public AmpiRequest {
  public:
-  bool cancelled  = false; // track if request is cancelled
-  bool persistent = false; // Is this a persistent recv request?
-  int length      = 0; // recv'ed length in bytes
+  bool cancelled   = false; // track if request is cancelled
+  bool persistent  = false; // Is this a persistent recv request?
+  int length       = 0; // recv'ed length in bytes
+  CkNcpyBuffer* targetInfo = nullptr;
+  char* systemBuf  = nullptr; // non-NULL for non-contiguous recv datatypes
+  int systemBufLen = 0; // length in bytes of systemBuf
 
   IReq(void *buf_, int count_, MPI_Datatype type_, int src_, int tag_,
        MPI_Comm comm_, CkDDT *ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
@@ -1289,11 +1307,34 @@ class IReq final : public AmpiRequest {
   int getNumReceivedBytes(CkDDT *ptr) const noexcept override {
     return length;
   }
+  void setSystemBuf(void* buf_, int len=0) noexcept override {
+    systemBuf = (char*)buf_;
+    systemBufLen = len;
+  }
+  void deregisterMem() noexcept override {
+    if (targetInfo) {
+      targetInfo->deregisterMem();
+      delete targetInfo;
+    }
+    if (systemBuf) {
+      delete [] systemBuf;
+    }
+  }
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
     p|cancelled;
     p|persistent;
     p|length;
+    p|systemBufLen;
+    p((char *)&systemBuf, sizeof(char *));
+    bool hasTargetInfo = (targetInfo != NULL);
+    p|hasTargetInfo;
+    if (hasTargetInfo) {
+      if (p.isUnpacking()) {
+        targetInfo = new CkNcpyBuffer();
+      }
+      p|*targetInfo;
+    }
   }
   void print() const noexcept override;
 };
@@ -1434,9 +1475,11 @@ class SendReq final : public AmpiRequest {
 
 class SsendReq final : public AmpiRequest {
  private:
+  bool systemBuf = false; // is 'buf' an intermediate/system buffer?
   bool persistent = false; // is this a persistent Ssend request?
  public:
   int destRank = MPI_PROC_NULL;
+  CkNcpyBuffer* srcInfo = nullptr;
 
  public:
   SsendReq(MPI_Datatype type_, MPI_Comm comm_, CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
@@ -1445,7 +1488,7 @@ class SsendReq final : public AmpiRequest {
     comm = comm_;
     AMPI_REQUEST_COMMON_INIT
   }
-  SsendReq(const void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
+  SsendReq(void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
            CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
   {
     buf      = (void*)buf_;
@@ -1456,7 +1499,7 @@ class SsendReq final : public AmpiRequest {
     destRank = dest_;
     AMPI_REQUEST_COMMON_INIT
   }
-  SsendReq(const void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
+  SsendReq(void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
            int src_, CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
   {
     buf      = (void*)buf_;
@@ -1480,10 +1523,30 @@ class SsendReq final : public AmpiRequest {
   AmpiReqType getType() const noexcept override { return AMPI_SSEND_REQ; }
   bool isUnmatched() const noexcept override { return false; }
   bool isPooledType() const noexcept override { return true; }
+  void deregisterMem() noexcept override {
+    if (srcInfo) {
+      srcInfo->deregisterMem();
+      delete srcInfo;
+    }
+    if (systemBuf) {
+      delete [] (char*)buf;
+    }
+  }
+  void setSystemBuf(void* buf_, int len=0) noexcept override {
+    systemBuf = true;
+    buf = buf_;
+  }
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
     p|persistent;
     p|destRank;
+    p|systemBuf;
+    bool hasSrcInfo = (srcInfo != NULL);
+    p|hasSrcInfo;
+    if (hasSrcInfo) {
+      if (p.isUnpacking()) srcInfo = new CkNcpyBuffer();
+      p|*srcInfo;
+    }
   }
   void print() const noexcept override;
 };
@@ -1650,6 +1713,12 @@ inline void pupFromBuf(const void *data,T &t) noexcept {
 
 #define COLL_SEQ_IDX      -1
 
+enum AmpiMsgType : bool {
+  NCPY_SHM_MSG = true,
+  NCPY_MSG     = false
+};
+PUPbytes(AmpiMsgType)
+
 class AmpiMsg final : public CMessage_AmpiMsg {
  private:
   int ssendReq; //Index to the sender's request (MPI_REQUEST_NULL if no request)
@@ -1666,9 +1735,9 @@ class AmpiMsg final : public CMessage_AmpiMsg {
 #endif
 
  public:
-  AmpiMsg() noexcept { data = NULL; }
-  AmpiMsg(int sreq, int t, int sRank, int l) noexcept :
-    ssendReq(sreq), tag(t), srcRank(sRank), length(l)
+  AmpiMsg(void) noexcept : data(NULL) {}
+  AmpiMsg(int sreq, int t, int sRank, int l, int c) noexcept :
+    ssendReq(sreq), tag(t), srcRank(sRank), length(l), comm(c)
   { /* only called from AmpiMsg::pup() since the refnum (seq) will get pup'ed by the runtime */ }
   AmpiMsg(CMK_REFNUM_TYPE seq, int sreq, int t, int sRank, int l) noexcept :
     ssendReq(sreq), tag(t), srcRank(sRank), length(l)
@@ -1691,26 +1760,54 @@ class AmpiMsg final : public CMessage_AmpiMsg {
       return srcRank;
     }
   }
-  inline int getSrcRank() const noexcept { return srcRank; }
-  inline int getLength() const noexcept { return length; }
-  inline char* getData() const noexcept { return data; }
-  inline int getTag() const noexcept { return tag; }
-  inline MPI_Comm getComm() const noexcept { return comm; }
+  inline AmpiMsgType isNcpyShmMsg(void) const noexcept { CkAssert(isSsend()); return ((AmpiMsgType*)data)[0]; }
+  inline void getNcpyShmBuffer(AmpiNcpyShmBuffer& srcInfo) noexcept {
+    CkAssert(isNcpyShmMsg());
+    PUP::fromMem p(data+sizeof(AmpiMsgType));
+    p | srcInfo;
+  }
+  inline void getNcpyBuffer(CkNcpyBuffer& srcInfo) noexcept {
+    CkAssert(!isNcpyShmMsg());
+    PUP::fromMem p(data+sizeof(AmpiMsgType));
+    p | srcInfo;
+  }
+  inline int getSrcRank(void) const noexcept { return srcRank; }
+  inline int getLength(void) const noexcept { return length; }
+  inline char* getData(void) const noexcept { return data; }
+  inline int getTag(void) const noexcept { return tag; }
+  inline MPI_Comm getComm(void) const noexcept { return comm; }
   static AmpiMsg* pup(PUP::er &p, AmpiMsg *m) noexcept
   {
-    int ssendReq, length, tag, srcRank, comm;
+    int ssendReq, length, tag, srcRank, comm, dataLen;
     if(p.isPacking() || p.isSizing()) {
       ssendReq = m->ssendReq;
       tag = m->tag;
       srcRank = m->srcRank;
       length = m->length;
       comm = m->comm;
+      if (m->isSsend()) {
+        // For SsendMsg's, m->data is a ncpyBuffer object and m->length
+        // is the length of the real msg payload to be recv'ed.
+        PUP::sizer pupSizer;
+        AmpiMsgType msgType;
+        pupSizer | msgType;
+        if (m->isNcpyShmMsg()) {
+          AmpiNcpyShmBuffer srcInfo;
+          pupSizer | srcInfo;
+        } else {
+          CkNcpyBuffer srcInfo;
+          pupSizer | srcInfo;
+        }
+        dataLen = pupSizer.size();
+      } else {
+        dataLen = length;
+      }
     }
-    p(ssendReq); p(tag); p(srcRank); p(length); p(comm);
+    p(ssendReq); p(tag); p(srcRank); p(length); p(comm); p(dataLen);
     if(p.isUnpacking()) {
-      m = new (length, 0) AmpiMsg(ssendReq, tag, srcRank, length, comm);
+      m = new (dataLen, 0) AmpiMsg(ssendReq, tag, srcRank, length, comm);
     }
-    p(m->data, length);
+    p(m->data, dataLen);
     if(p.isDeleting()) {
       delete m;
       m = 0;
@@ -1719,8 +1816,8 @@ class AmpiMsg final : public CMessage_AmpiMsg {
   }
 };
 
-#define AMPI_MSG_POOL_SIZE   32 // Max # of AmpiMsg's allowed in the pool
-#define AMPI_POOLED_MSG_SIZE 64 // Max # of Bytes in pooled msgs' payload
+#define AMPI_MSG_POOL_SIZE    32 // Max # of AmpiMsg's allowed in the pool
+#define AMPI_POOLED_MSG_SIZE 128 // Max # of Bytes in pooled msgs' payload
 
 class AmpiMsgPool {
  private:
@@ -1941,7 +2038,7 @@ class AmpiRequestPool {
       return NULL;
     }
   }
-  inline SsendReq* newSsendReq(const void* buf, int count, MPI_Datatype type, int dest, int tag,
+  inline SsendReq* newSsendReq(void* buf, int count, MPI_Datatype type, int dest, int tag,
                                MPI_Comm comm, int src, CkDDT* ddt, AmpiReqSts sts=AMPI_REQ_PENDING) noexcept {
     if (validReqs.all()) {
       return new SsendReq(buf, count, type, dest, tag, comm, src, ddt, sts);
@@ -2518,6 +2615,7 @@ class ampiParent final : public CBase_ampiParent {
     (func)((void*)invec, inoutvec, &count, &datatype);
   }
 
+  int wait(MPI_Request* req, MPI_Status* sts) noexcept;
   void init() noexcept;
   void finalize() noexcept;
   void block() noexcept;
@@ -2617,8 +2715,8 @@ class ampi final : public CBase_ampi {
   ampi() noexcept;
   ampi(CkArrayID parent_,const ampiCommStruct &s) noexcept;
   ampi(CkMigrateMessage *msg) noexcept;
-  void ckJustMigrated() noexcept;
-  void ckJustRestored() noexcept;
+  void ckJustMigrated(void) noexcept;
+  void ckJustRestored(void) noexcept;
   ~ampi() noexcept;
 
   void pup(PUP::er &p) noexcept;
@@ -2631,7 +2729,8 @@ class ampi final : public CBase_ampi {
   void generic(AmpiMsg *) noexcept;
   void genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept;
   void completedRdmaSend(CkDataMsg *msg) noexcept;
-  void ssendAck(int sreqIdx) noexcept;
+  void completedRdmaRecv(CkDataMsg *msg) noexcept;
+  void requestPut(MPI_Request req, CkNcpyBuffer targetInfo) noexcept;
   void barrierResult(void) noexcept;
   void ibarrierResult(void) noexcept;
   void rednResult(CkReductionMsg *msg) noexcept;
@@ -2670,13 +2769,18 @@ class ampi final : public CBase_ampi {
   inline ampi* blockOnRedn(AmpiRequest *req) noexcept;
   MPI_Request postReq(AmpiRequest* newreq) noexcept;
   inline void waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept;
-  inline void requestSsendMsg(AmpiMsg* msg) noexcept;
   inline void completedSend(MPI_Request req) noexcept;
+  inline void completedRecv(MPI_Request req) noexcept;
 
   inline CMK_REFNUM_TYPE getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcept;
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,MPI_Comm destcomm) noexcept;
-  AmpiMsg *makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count,
-                       MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg *makeSyncMsg(int t,int sRank,const void *buf,int count,
+                       MPI_Datatype type,CProxy_ampi destProxy,
+                       int destIdx,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg *makeNcpyShmMsg(int t, int sRank, const void* buf, int count,
+                          MPI_Datatype type, int ssendReq, int seq) noexcept;
+  AmpiMsg *makeNcpyMsg(int t, int sRank, const void* buf, int count,
+                       MPI_Datatype type, int ssendReq, int seq) noexcept;
   AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
                        MPI_Datatype type,MPI_Comm destcomm) noexcept;
   AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
@@ -2686,11 +2790,11 @@ class ampi final : public CBase_ampi {
                    MPI_Comm destcomm, AmpiSendType sendType=BLOCKING_SEND, MPI_Request=MPI_REQUEST_NULL) noexcept;
   static void sendraw(int t, int s, void* buf, int len, CkArrayID aid, int idx) noexcept;
   inline MPI_Request sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                                 int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxyElement_ampi destElem,
-                                 AmpiSendType sendType, MPI_Request reqIdx) noexcept;
-  inline MPI_Request sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
-                                  int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
-                                  ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
+                                 int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi destElem,
+                                 int destIdx, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
+  inline MPI_Request sendLocalInOrderMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
+                                         int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
+                                         ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
   inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
                                  int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
                                  MPI_Request reqIdx) noexcept;
@@ -2708,10 +2812,11 @@ class ampi final : public CBase_ampi {
   }
   inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
                               MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;
-  inline bool processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept;
-  inline bool processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
-  inline void processRdmaMsg(const void *sbuf, int slength, int srank, void* rbuf,
-                             int rcount, MPI_Datatype rtype, MPI_Comm comm) noexcept;
+  inline bool processSsendMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
+  inline bool processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
+  inline bool processSsendNcpyMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
+  inline bool processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
+  inline void processRdmaMsg(const void *sbuf, int slength, void* rbuf, int rcount, MPI_Datatype rtype) noexcept;
   inline void processRednMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
   inline void processNoncommutativeRednMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type, int count,
                                            MPI_User_function* func) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -105,8 +105,14 @@ class fromzDisk : public zdisk {
 
 /* AMPI sends messages inline to PE-local destination VPs if: BigSim is not being used and
  * if tracing is not being used (see bug #1640 for more details on the latter). */
-#ifndef AMPI_LOCAL_IMPL
-#define AMPI_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
+#ifndef AMPI_PE_LOCAL_IMPL
+#define AMPI_PE_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
+#endif
+
+/* AMPI sends messages using a zero copy protocol to Node-local destination VPs if:
+ * BigSim is not being used and if tracing is not being used (such msgs are currently untraced). */
+#ifndef AMPI_NODE_LOCAL_IMPL
+#define AMPI_NODE_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
 /* messages larger than or equal to this threshold may block on a matching recv if local to the PE*/
@@ -116,7 +122,16 @@ class fromzDisk : public zdisk {
 
 /* messages larger than or equal to this threshold may block on a matching recv if local to the Node */
 #ifndef AMPI_NODE_LOCAL_THRESHOLD_DEFAULT
-#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 16384
+#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 12288
+#endif
+
+/* messages larger than or equal to this threshold will always block on a matching recv */
+#ifndef AMPI_SSEND_THRESHOLD_DEFAULT
+#if CMK_USE_IBVERBS || CMK_CONVERSE_UGNI
+#define AMPI_SSEND_THRESHOLD_DEFAULT 262144
+#else
+#define AMPI_SSEND_THRESHOLD_DEFAULT 102400
+#endif
 #endif
 
 /* AMPI uses RDMA sends if BigSim is not being used. */
@@ -126,7 +141,7 @@ class fromzDisk : public zdisk {
 
 /* contiguous messages larger than or equal to this threshold are sent via RDMA */
 #ifndef AMPI_RDMA_THRESHOLD_DEFAULT
-#if CMK_USE_IBVERBS || CMK_OFI || CMK_CONVERSE_UGNI
+#if CMK_USE_IBVERBS || CMK_CONVERSE_UGNI
 #define AMPI_RDMA_THRESHOLD_DEFAULT 65536
 #else
 #define AMPI_RDMA_THRESHOLD_DEFAULT 32768

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2616,6 +2616,7 @@ class ampiParent final : public CBase_ampiParent {
   }
 
   int wait(MPI_Request* req, MPI_Status* sts) noexcept;
+  int waitall(int count, MPI_Request request[], MPI_Status sts[]=MPI_STATUSES_IGNORE) noexcept;
   void init() noexcept;
   void finalize() noexcept;
   void block() noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2849,30 +2849,32 @@ class ampi final : public CBase_ampi {
 
   inline CMK_REFNUM_TYPE getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcept;
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,MPI_Comm destcomm) noexcept;
-  AmpiMsg *makeSyncMsg(int t,int sRank,const void *buf,int count,
-                       MPI_Datatype type,CProxy_ampi destProxy,
-                       int destIdx,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
-  AmpiMsg *makeNcpyShmMsg(int t, int sRank, const void* buf, int count,
-                          MPI_Datatype type, int ssendReq, int seq) noexcept;
-  AmpiMsg *makeNcpyMsg(int t, int sRank, const void* buf, int count,
-                       MPI_Datatype type, int ssendReq, int seq) noexcept;
-  AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
-                       MPI_Datatype type,MPI_Comm destcomm) noexcept;
-  AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
-                       MPI_Datatype type,MPI_Comm destcomm,CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg *makeSyncMsg(const void* buf, int count, MPI_Datatype type, int srcRank,
+                       int tag, MPI_Comm comm, CProxy_ampi destProxy, int destIdx,
+                       int ssendReq, CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg* makeNcpyShmMsg(const void* buf, int count, MPI_Datatype type, int srcRank,
+                          int tag, int ssendReq, CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg* makeNcpyMsg(const void* buf, int count, MPI_Datatype type, int srcRank,
+                       int tag, int ssendReq, CMK_REFNUM_TYPE seq) noexcept;
+  AmpiMsg *makeAmpiMsg(const void* buf, int count, MPI_Datatype type, int destRank,
+                       int tag, MPI_Comm comm, int srcRank) noexcept;
+  AmpiMsg *makeAmpiMsg(const void* buf, int count, MPI_Datatype type, int destRank,
+                       int tag, MPI_Comm comm, int srcRank, CMK_REFNUM_TYPE seq) noexcept;
 
-  MPI_Request send(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
-                   MPI_Comm destcomm, AmpiSendType sendType=BLOCKING_SEND, MPI_Request=MPI_REQUEST_NULL) noexcept;
+  MPI_Request send(const void* buf, int count, MPI_Datatype type, int destRank, int tag,
+                   MPI_Comm comm, AmpiSendType sendType=BLOCKING_SEND,
+                   MPI_Request reqIdx=MPI_REQUEST_NULL) noexcept;
   static void sendraw(int t, int s, void* buf, int len, CkArrayID aid, int idx) noexcept;
-  inline MPI_Request sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                                 int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi destElem,
-                                 int destIdx, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
-  inline MPI_Request sendLocalInOrderMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
-                                         int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
-                                         ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
-  inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                                 int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
-                                 MPI_Request reqIdx) noexcept;
+  inline MPI_Request sendSyncMsg(const void* buf, int count, MPI_Datatype type, int destRank,
+                                 int tag, MPI_Comm comm, AmpiSendType sendType,
+                                 MPI_Request reqIdx, int srcRank, CMK_REFNUM_TYPE seq,
+                                 ampi* destPtr, CProxy_ampi arrProxy, int destIdx) noexcept;
+  inline MPI_Request sendLocalInOrderMsg(const void* buf, int count, MPI_Datatype type, int destRank,
+                                         int tag, MPI_Comm comm, AmpiSendType sendType, MPI_Request reqIdx,
+                                         int srcRank, CMK_REFNUM_TYPE seq, int size, ampi* destPtr) noexcept;
+  inline MPI_Request sendRdmaMsg(const void* buf, int size, MPI_Datatype type, int destRank,
+                                 int tag, MPI_Comm comm, int reqIdx, CMK_REFNUM_TYPE seq,
+                                 CProxy_ampi arrProxy, int destIdx) noexcept;
   inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
 #if CMK_MULTICORE
     return true;
@@ -2885,8 +2887,8 @@ class ampi final : public CBase_ampi {
     return (destPtr != NULL);
 #endif
   }
-  inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
-                              MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;
+  inline MPI_Request delesend(const void* buf, int count, MPI_Datatype type, int destRank, int tag,
+                              MPI_Comm comm, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
   inline bool processSsendMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
   inline bool processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;
   inline bool processSsendNcpyMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int count, MPI_Request req) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2901,13 +2901,10 @@ class ampi final : public CBase_ampi {
   inline void processGathervMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type,
                                int* recvCounts, int* displs) noexcept;
   inline AmpiMsg * getMessage(int t, int s, MPI_Comm comm, int *sts) const noexcept;
-  int recv(int t,int s,void* buf,int count,MPI_Datatype type,MPI_Comm comm,MPI_Status *sts=NULL) noexcept;
-  void irecv(void *buf, int count, MPI_Datatype type, int src,
-             int tag, MPI_Comm comm, MPI_Request *request) noexcept;
-  void mrecv(int tag, int src, void* buf, int count, MPI_Datatype datatype, MPI_Comm comm,
-             MPI_Status* status, MPI_Message* message) noexcept;
-  void imrecv(void* buf, int count, MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
-              MPI_Request* request, MPI_Message* message) noexcept;
+  int recv(void* buf, int count, MPI_Datatype type, int src, int tag,
+           MPI_Comm comm, MPI_Status *sts=MPI_STATUS_IGNORE) noexcept;
+  int irecv(void *buf, int count, MPI_Datatype type, int src,
+            int tag, MPI_Comm comm, MPI_Request *request) noexcept;
   void sendrecv(const void *sbuf, int scount, MPI_Datatype stype, int dest, int stag,
                 void *rbuf, int rcount, MPI_Datatype rtype, int src, int rtag,
                 MPI_Comm comm, MPI_Status *sts) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -109,9 +109,14 @@ class fromzDisk : public zdisk {
 #define AMPI_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
-/* messages larger than or equal to this threshold may block on a matching recv if local */
-#ifndef AMPI_LOCAL_THRESHOLD_DEFAULT
-#define AMPI_LOCAL_THRESHOLD_DEFAULT 4096
+/* messages larger than or equal to this threshold may block on a matching recv if local to the PE*/
+#ifndef AMPI_PE_LOCAL_THRESHOLD_DEFAULT
+#define AMPI_PE_LOCAL_THRESHOLD_DEFAULT 4096
+#endif
+
+/* messages larger than or equal to this threshold may block on a matching recv if local to the Node */
+#ifndef AMPI_NODE_LOCAL_THRESHOLD_DEFAULT
+#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 16384
 #endif
 
 /* AMPI uses RDMA sends if BigSim is not being used and the underlying comm
@@ -129,14 +134,7 @@ class fromzDisk : public zdisk {
 #endif
 #endif
 
-/* contiguous messages larger than or equal to this threshold that are being sent
- * within a process are sent via RDMA. */
-#ifndef AMPI_SMP_RDMA_THRESHOLD_DEFAULT
-#define AMPI_SMP_RDMA_THRESHOLD_DEFAULT 16384
-#endif
-
 extern int AMPI_RDMA_THRESHOLD;
-extern int AMPI_SMP_RDMA_THRESHOLD;
 
 #define AMPI_ALLTOALL_THROTTLE   64
 #define AMPI_ALLTOALL_SHORT_MSG  256
@@ -282,6 +280,30 @@ class AmpiOpHeader {
   AmpiOpHeader(MPI_User_function* f,MPI_Datatype d,int l,int szd) noexcept :
     func(f),dtype(d),len(l),szdata(szd) { }
 };
+
+/*
+ * For within-node Ssend's: used in ampi::processSsendMsg()
+ */
+class SsendInfo {
+ private:
+  int node;
+  int idx;
+  int count;
+  char* buf;
+  CkDDT_DataType* ddt;
+
+ public:
+  SsendInfo() = default;
+  SsendInfo(int idx_, int count_, char* buf_, CkDDT_DataType* ddt_) noexcept :
+    node(CkMyNode()), idx(idx_), count(count_), buf(buf_), ddt(ddt_) {}
+  ~SsendInfo() {}
+  inline int getNode() const noexcept { return node; }
+  inline int getIdx() const noexcept { return idx; }
+  inline int getCount() const noexcept { return count; }
+  inline char* getBuf() const noexcept { CkAssert(node == CkMyNode()); return buf; }
+  inline CkDDT_DataType* getDDT() const noexcept { CkAssert(node == CkMyNode()); return ddt; }
+};
+PUPbytes(SsendInfo) // PUP as bytes b/c buf & ddt are only meant to be accessed from within shared memory
 
 //------------------- added by YAN for one-sided communication -----------
 /* the index is unique within a communicator */
@@ -2673,9 +2695,16 @@ class ampi final : public CBase_ampi {
                                  int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
                                  MPI_Request reqIdx) noexcept;
   inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
+#if CMK_MULTICORE
+    return true;
+#elif CMK_SMP
     CkArray* localBranch = arrProxy.ckLocalBranch();
     int destPe = localBranch->lastKnown(CkArrayIndex1D(destIdx));
     return (CkNodeOf(destPe) == CkMyNode());
+#else // non-SMP
+    ampi* destPtr = arrProxy[destIdx].ckLocal();
+    return (destPtr != NULL);
+#endif
   }
   inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
                               MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;

--- a/src/libs/ck-libs/ampi/mpich-alltoall.C
+++ b/src/libs/ck-libs/ampi/mpich-alltoall.C
@@ -410,9 +410,8 @@ int AMPI_Alltoall_medium(
 	dst = (rank+i) % comm_size;
 	/*mpi_errno = MPI_Isend((char *)sendbuf + dst*sendcount*sendtype_extent,
 	    sendcount, sendtype, dst, MPI_ATA_TAG, comm, &reqarray[i+comm_size]);*/
-	ptr->send(MPI_ATA_TAG, getAmpiInstance(comm)->getRank(),
-              (char *)sendbuf + dst*sendcount*sendtype_extent,
-		      sendcount, sendtype, dst, comm);
+	ptr->send((char *)sendbuf + dst*sendcount*sendtype_extent, sendcount,
+            sendtype, dst, MPI_ATA_TAG, comm);
 	reqarray[i+comm_size] = MPI_REQUEST_NULL;
   }
 


### PR DESCRIPTION
*Original PR: https://charm.cs.illinois.edu/gerrit/4639*

---
Change-Id: I8892c11b34ad94ad6e6f6e2fc9bc5674b22d43af