### PR TITLE
fix the bug of using CkMyRank before ConverseInit

### DIFF
--- a/src/ck-core/register.h
+++ b/src/ck-core/register.h
@@ -269,11 +269,6 @@ public:
 	/// Add a heap-allocated registration record,
 	///  returning the index used.
 	int add(T *t) {
-#if CMK_ERROR_CHECKING
-		/* Make sure registrations only happen from rank 0: */
-		if (CkMyRank()!=0)
-			CkAbort("Can only do registrations from rank 0 processors");
-#endif
 		vec.push_back(t);
 		return vec.size()-1;
 	}


### PR DESCRIPTION
*Original author: YanhuaSun*
*Original PR: https://charm.cs.illinois.edu/gerrit/362*

---
Change-Id: I82423c1ec95220a7365ff7bb4c1de2d93a2d1c43