### PR TITLE
C++AMP direct method example

### DIFF
--- a/examples/charm++/hello/1darray/Makefile
+++ b/examples/charm++/hello/1darray/Makefile
@@ -1,4 +1,8 @@
 -include ../../../common.mk
+LD=-ld clang++
+CXX_OPT=$(shell clamp-config --build --cxxflags | tr ' ' "\n" |  sed -e 's/^/\-c\+\+\-option\ /g' | xargs)
+LDXX_OPT=$(shell clamp-config --build --ldflags | tr ' ' "\n" |  sed -e 's/^/\-ld\+\+\-option\ /g' | xargs)
+OPTS+=$(CXX_OPT) $(LD) $(LDXX_OPT)
 CHARMC=../../../../bin/charmc $(OPTS)
 
 OBJS = hello.o

--- a/examples/charm++/hello/1darray/hello.C
+++ b/examples/charm++/hello/1darray/hello.C
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "hello.decl.h"
+#include <amp.h>
 
 /*readonly*/ CProxy_Main mainProxy;
 /*readonly*/ int nElements;
@@ -46,6 +47,31 @@ public:
   void SayHi(int hiNo)
   {
     CkPrintf("Hi[%d] from element %d\n",hiNo,thisIndex);
+#if 1
+    using namespace concurrency;
+    std::vector<int> data(5);
+    for (int count = 0; count < 5; count++)
+    {
+         data[count] = thisIndex + count;
+    }
+
+    array<int, 1> a(5, data.begin(), data.end());
+
+    parallel_for_each(
+        a.get_extent(),
+        [=, &a](index<1> idx) restrict(amp)
+        {
+            a[idx] = a[idx] * 10;
+        }
+    );
+
+    data = a;
+    for (int i = 0; i < 5; i++)
+    {
+        CkPrintf("%d ", data[i]);
+    }
+    CkPrintf("\n");
+#endif
     if (thisIndex < nElements-1)
       //Pass the hello on:
       thisProxy[thisIndex+1].SayHi(hiNo+1);

--- a/src/scripts/conv-config.sh
+++ b/src/scripts/conv-config.sh
@@ -71,6 +71,9 @@ then
 . $CHARMINC/conv-mach-opt.sh
 fi
 
+# strip out c++0x flag while we're under amp mode
+OPTS_CXX=`echo $OPTS_CXX | awk '/c\+\+amp/{ gsub(/\-std\=c\+\+0x/, ""); print; }'`
+
 OPTS_CC="$OPTS_CC $USER_OPTS_CC"
 OPTS_CXX="$OPTS_CXX $USER_OPTS_CXX"
 OPTS_LD="$OPTS_LD $USER_OPTS_LD"


### PR DESCRIPTION
*Original author: Yan-Ming Li*
*Original date: 2015-07-28 00:39:30*
*Original PR: https://charm.cs.illinois.edu/gerrit/761*

---

- This requires [MCW's C++AMP compiler](https://bitbucket.org/multicoreware/cppamp-driver-ng/wiki/Home)

- Our -std=c++amp is conflicted with -std=c++0x, so we need to strip it
  out in conv-config.sh

Change-Id: I76cb211cbf2a745d858f3986eb4bc9dc1d42c00b